### PR TITLE
fix(cli): load custom Cedar policies in serve path (closes #57)

### DIFF
--- a/crates/schema-forge-acton/src/actor.rs
+++ b/crates/schema-forge-acton/src/actor.rs
@@ -7,6 +7,7 @@
 //! that the handler uses to send the result back to the caller.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use acton_service::prelude::*;
@@ -44,6 +45,12 @@ pub struct ForgeActor {
     pub(crate) hook_dispatcher: Option<Arc<dyn HookDispatcher>>,
     pub(crate) storage_registry: StorageRegistry,
     pub(crate) policy_store: Option<Arc<crate::authz::PolicyStore>>,
+    /// Custom Cedar policy directory threaded through from the CLI/config
+    /// at `InitForge` time. Used by [`recompile_policy_store`] so that
+    /// runtime schema mutations recompile against the same bundle the
+    /// daemon started with — without it, a schema mutation would silently
+    /// strip operator-authored policies from the live `PolicyStore`.
+    pub(crate) custom_policies_dir: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for ForgeActor {
@@ -79,6 +86,7 @@ impl ForgeActor {
             hook_dispatcher: None,
             storage_registry: StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
         }
     }
 }
@@ -108,6 +116,7 @@ fn configure_init(actor: &mut ManagedActor<Idle, ForgeActor>) {
         actor.model.tenant_config = msg.tenant_config.clone();
         actor.model.hook_dispatcher = msg.hook_dispatcher.clone();
         actor.model.storage_registry = msg.storage_registry.clone();
+        actor.model.custom_policies_dir = msg.custom_policies_dir.clone();
 
         // Lazy-init the policy store when the caller did not supply one. The
         // CLI / extension build paths always pass it, but tests and ad-hoc
@@ -322,7 +331,8 @@ fn recompile_policy_store(
     };
 
     let schemas: Vec<SchemaDefinition> = model.registry.values().cloned().collect();
-    match store.recompile_from_schemas(&schemas, None) {
+    let custom_dir = model.custom_policies_dir.as_deref();
+    match store.recompile_from_schemas(&schemas, custom_dir) {
         Ok(()) => {
             tracing::info!(
                 target: "schema_forge_acton::authz",

--- a/crates/schema-forge-acton/src/authz/store.rs
+++ b/crates/schema-forge-acton/src/authz/store.rs
@@ -344,6 +344,55 @@ mod tests {
     }
 
     #[test]
+    fn recompile_from_schemas_merges_custom_dir() {
+        // Regression for issue #57: the live serve recompile path used to
+        // pass `None` for `custom_dir`, silently dropping operator-authored
+        // policies. Prove the recompile now picks up a valid custom forbid
+        // and grows the bundle, with a different hash than the generated-only
+        // snapshot.
+        let baseline = PolicyStoreSnapshot::from_schemas(
+            &[schema_named("Alpha")],
+            None,
+            RoleRanks::empty(),
+            PrincipalClaimMappings::default(),
+        )
+        .unwrap();
+        let baseline_count = baseline.policy_count;
+        let baseline_hash = baseline.policy_hash.clone();
+        let store = PolicyStore::new(baseline);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("scope.cedar"),
+            r#"
+                @id("custom.deny_all_alpha")
+                forbid (
+                    principal is Forge::Principal,
+                    action,
+                    resource is Alpha
+                );
+            "#,
+        )
+        .unwrap();
+
+        store
+            .recompile_from_schemas(&[schema_named("Alpha")], Some(tmp.path()))
+            .expect("recompile with custom_dir should succeed");
+
+        let current = store.current();
+        assert!(
+            current.policy_count > baseline_count,
+            "custom forbid policy must be merged into the bundle ({} -> {})",
+            baseline_count,
+            current.policy_count,
+        );
+        assert_ne!(
+            current.policy_hash, baseline_hash,
+            "policy hash must change once custom_dir is loaded",
+        );
+    }
+
+    #[test]
     fn recompile_from_schemas_keeps_old_bundle_on_failure() {
         // Build a healthy bundle, then point recompile at a custom-policy
         // directory whose Cedar source fails to validate. The store must

--- a/crates/schema-forge-acton/src/config.rs
+++ b/crates/schema-forge-acton/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use schema_forge_signing::SigningConfig;
 use serde::{Deserialize, Serialize};
 
@@ -106,6 +108,15 @@ pub struct AuthzConfig {
     /// subsections.
     #[serde(default)]
     pub principal_claims: PrincipalClaimsConfig,
+
+    /// Directory holding additional `*.cedar` policies that the running
+    /// daemon merges into the Cedar bundle on every recompile. Equivalent
+    /// to `schemaforge policies validate --custom-dir` but for the live
+    /// serve path. `serve --custom-dir` overrides this; when neither is
+    /// set the daemon auto-discovers `policies/custom` relative to the
+    /// working directory if that directory exists.
+    #[serde(default)]
+    pub custom_policies_dir: Option<PathBuf>,
 }
 
 fn default_route_prefix() -> String {

--- a/crates/schema-forge-acton/src/extension.rs
+++ b/crates/schema-forge-acton/src/extension.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use axum::Router;
@@ -405,6 +406,7 @@ impl SchemaForgeExtension {
         storage_config: &StorageConfig,
         role_ranks: crate::authz::role_ranks::RoleRanks,
         principal_claims: crate::authz::principal_claims::PrincipalClaimMappings,
+        custom_policies_dir: Option<&Path>,
     ) -> Result<InitForgeData, ForgeError> {
         // Load existing schemas from the backend into a HashMap
         let stored_schemas = backend
@@ -467,7 +469,7 @@ impl SchemaForgeExtension {
         let policy_store = crate::authz::PolicyStore::new(
             crate::authz::store::PolicyStoreSnapshot::from_schemas(
                 &all_schemas,
-                None,
+                custom_policies_dir,
                 role_ranks,
                 principal_claims,
             )

--- a/crates/schema-forge-acton/src/messages.rs
+++ b/crates/schema-forge-acton/src/messages.rs
@@ -253,6 +253,11 @@ pub struct InitForge {
     pub hook_dispatcher: Option<Arc<dyn crate::hooks::HookDispatcher>>,
     pub storage_registry: crate::storage::StorageRegistry,
     pub policy_store: Option<Arc<crate::authz::PolicyStore>>,
+    /// Directory holding `*.cedar` custom policies merged into the runtime
+    /// bundle on every recompile. `None` means no custom policies (the
+    /// auto-discovered default falls through to `None` when
+    /// `policies/custom` is absent).
+    pub custom_policies_dir: Option<std::path::PathBuf>,
     pub reply: ReplyChannel<()>,
 }
 

--- a/crates/schema-forge-acton/tests/auth_demo.rs
+++ b/crates/schema-forge-acton/tests/auth_demo.rs
@@ -112,6 +112,7 @@ async fn build_test_app_state(
             hook_dispatcher: None,
             storage_registry: schema_forge_acton::storage::StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
             reply: ReplyChannel::new(tx),
         })
         .await;

--- a/crates/schema-forge-acton/tests/hooks_integration.rs
+++ b/crates/schema-forge-acton/tests/hooks_integration.rs
@@ -140,6 +140,7 @@ async fn setup(
                 .map(|d| d as Arc<dyn schema_forge_acton::hooks::HookDispatcher>),
             storage_registry: schema_forge_acton::storage::StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
             reply: ReplyChannel::new(tx),
         })
         .await;
@@ -695,6 +696,7 @@ async fn after_change_writeback_to_trigger_entity_is_eventually_consistent() {
             hook_dispatcher: Some(writeback),
             storage_registry: schema_forge_acton::storage::StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
             reply: schema_forge_acton::messages::ReplyChannel::new(init_tx),
         })
         .await;

--- a/crates/schema-forge-acton/tests/integration.rs
+++ b/crates/schema-forge-acton/tests/integration.rs
@@ -80,6 +80,7 @@ async fn build_test_app_state(init: TestForgeInit) -> AppState<SchemaForgeConfig
             hook_dispatcher: init.hook_dispatcher,
             storage_registry: schema_forge_acton::storage::StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
             reply: ReplyChannel::new(tx),
         })
         .await;

--- a/crates/schema-forge-acton/tests/users.rs
+++ b/crates/schema-forge-acton/tests/users.rs
@@ -158,6 +158,7 @@ async fn users_router(seeded: SeededBackend, claims: Claims) -> Router {
             hook_dispatcher: None,
             storage_registry: schema_forge_acton::storage::StorageRegistry::default(),
             policy_store: None,
+            custom_policies_dir: None,
             reply: ReplyChannel::new(tx),
         })
         .await;

--- a/crates/schema-forge-cli/src/cli.rs
+++ b/crates/schema-forge-cli/src/cli.rs
@@ -748,6 +748,15 @@ pub struct ServeArgs {
     /// (only `platform_admin` carries a rank).
     #[arg(long = "role-ranks", default_value = "policies/role_ranks.toml")]
     pub role_ranks: PathBuf,
+
+    /// Directory containing additional `*.cedar` policies to merge into
+    /// the runtime bundle (e.g. `policies/custom/`). Overrides
+    /// `[schema_forge.authz] custom_policies_dir` in config.toml. When
+    /// neither is set, the daemon auto-discovers `policies/custom`
+    /// relative to the working directory if that directory exists.
+    /// Missing explicitly-named directories are treated as empty.
+    #[arg(long = "custom-dir")]
+    pub custom_dir: Option<PathBuf>,
 }
 
 /// Export subcommands.

--- a/crates/schema-forge-cli/src/commands/bootstrap_admin.rs
+++ b/crates/schema-forge-cli/src/commands/bootstrap_admin.rs
@@ -69,6 +69,7 @@ pub async fn run(
         &svc_config.custom.schema_forge.storage,
         role_ranks,
         principal_claims,
+        None,
     )
     .await
     .map_err(|e| CliError::Server {

--- a/crates/schema-forge-cli/src/commands/serve.rs
+++ b/crates/schema-forge-cli/src/commands/serve.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -97,6 +98,32 @@ pub async fn run(
         message: format!("invalid [schema_forge.authz.principal_claims]: {e}"),
     })?;
 
+    // 4c. Resolve the custom-policies directory. CLI `--custom-dir` overrides
+    //     `[schema_forge.authz] custom_policies_dir` in config.toml. When
+    //     neither is set, auto-discover `policies/custom` relative to the
+    //     working directory only when that directory exists, so deployments
+    //     without the convention don't generate a misleading log line. An
+    //     explicitly-named missing directory is still passed through —
+    //     `load_custom_policies` treats it as empty — but we warn so the
+    //     misconfiguration is visible. Fixes issue #57.
+    let custom_dir = resolve_custom_policies_dir(
+        args.custom_dir.as_deref(),
+        svc_config
+            .custom
+            .schema_forge
+            .authz
+            .custom_policies_dir
+            .as_deref(),
+    );
+    if let Some(dir) = custom_dir.as_deref() {
+        if !dir.exists() {
+            output.warn(&format!(
+                "custom policies directory {} does not exist; bundle will use generated policies only",
+                dir.display()
+            ));
+        }
+    }
+
     // 5. Build ForgeActor initialization data (loads schemas, seeds system schemas, builds tenant config)
     let init_data = SchemaForgeExtension::build_init(
         backend_arc.clone(),
@@ -104,6 +131,7 @@ pub async fn run(
         &storage_config,
         role_ranks,
         principal_claims,
+        custom_dir.as_deref(),
     )
     .await
     .map_err(|e| CliError::Server {
@@ -165,10 +193,24 @@ pub async fn run(
     // an app schema with "type X is not declared in the schema".
     if let Some(policy_store) = &init_data.policy_store {
         policy_store
-            .recompile_from_schemas(&all_schemas, None)
+            .recompile_from_schemas(&all_schemas, custom_dir.as_deref())
             .map_err(|e| CliError::Server {
                 message: format!("Cedar policy recompile failed after schema apply: {e}"),
             })?;
+
+        // Log the final bundle posture so misconfiguration (missing custom
+        // policies, wrong directory) is obvious at startup. Mirrors the
+        // success line `schemaforge policies validate` already prints.
+        let snap = policy_store.current();
+        let custom_suffix = custom_dir
+            .as_deref()
+            .map(|d| format!(" (custom: {})", d.display()))
+            .unwrap_or_default();
+        output.success(&format!(
+            "Cedar bundle loaded: {} policies, hash {}{custom_suffix}",
+            snap.policy_count,
+            &snap.policy_hash[..16],
+        ));
     }
 
     // Phase-2 principal-claim validation: bind every `source.user_field`
@@ -377,6 +419,7 @@ pub async fn run(
             hook_dispatcher,
             storage_registry: init_data.storage_registry,
             policy_store: init_data.policy_store,
+            custom_policies_dir: custom_dir.clone(),
             reply: ReplyChannel::new(tx),
         })
         .await;
@@ -675,6 +718,32 @@ fn wrap_health_with_schema_forge_version(
     }
 }
 
+/// Resolve the custom-Cedar-policies directory for the live serve path.
+///
+/// Precedence:
+/// 1. `--custom-dir` on the command line.
+/// 2. `[schema_forge.authz] custom_policies_dir` in `config.toml`.
+/// 3. `policies/custom` relative to the working directory **iff** that
+///    directory exists. Auto-discovery is suppressed when the directory is
+///    absent so deployments that don't use the convention don't get a
+///    misleading "custom: policies/custom" log line.
+///
+/// An explicitly-named missing directory is still returned so the caller can
+/// warn the operator; `load_custom_policies` already treats it as empty.
+fn resolve_custom_policies_dir(
+    cli_dir: Option<&Path>,
+    config_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(p) = cli_dir {
+        return Some(p.to_path_buf());
+    }
+    if let Some(p) = config_dir {
+        return Some(p.to_path_buf());
+    }
+    let default = PathBuf::from("policies/custom");
+    default.is_dir().then_some(default)
+}
+
 /// Build a `MetaInfo` snapshot from the resolved DB params.
 ///
 /// `backend` and `backend_label` are picked off the `DbParams` variant so
@@ -691,6 +760,69 @@ fn build_meta_info(db_params: &DbParams) -> Arc<schema_forge_acton::MetaInfo> {
     };
     let ttl = schema_forge_acton::routes::auth::LOGIN_TOKEN_LIFETIME.as_secs();
     Arc::new(schema_forge_acton::MetaInfo::new(backend, label, ttl))
+}
+
+/// Backend-agnostic tests for `resolve_custom_policies_dir`. Kept out of the
+/// SurrealDB-gated module below so they run on every build.
+#[cfg(test)]
+mod resolve_tests {
+    use super::resolve_custom_policies_dir;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    // CWD is process-global. Serialize the two tests below that mutate it
+    // so they don't race against each other under `cargo nextest run`.
+    static CWD_GUARD: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn cli_flag_wins_over_config() {
+        let cli = PathBuf::from("/cli/custom");
+        let cfg = PathBuf::from("/cfg/custom");
+        let got = resolve_custom_policies_dir(Some(&cli), Some(&cfg));
+        assert_eq!(got.as_deref(), Some(cli.as_path()));
+    }
+
+    #[test]
+    fn config_used_when_cli_absent() {
+        let cfg = PathBuf::from("/cfg/custom");
+        let got = resolve_custom_policies_dir(None, Some(&cfg));
+        assert_eq!(got.as_deref(), Some(cfg.as_path()));
+    }
+
+    #[test]
+    fn explicit_missing_dir_is_passed_through_for_warning() {
+        // Resolver does not stat the explicit path — `load_custom_policies`
+        // treats a missing directory as empty, and the caller emits a warn
+        // line. The resolver must return the path so the caller can warn.
+        let cli = PathBuf::from("/definitely/does/not/exist");
+        let got = resolve_custom_policies_dir(Some(&cli), None);
+        assert_eq!(got.as_deref(), Some(cli.as_path()));
+    }
+
+    #[test]
+    fn default_returns_none_when_policies_custom_missing() {
+        // Run from a temp dir with no `policies/custom` subdirectory so
+        // the auto-discovery branch returns None instead of a phantom path.
+        let _guard = CWD_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(tmp.path()).expect("set cwd");
+        let got = resolve_custom_policies_dir(None, None);
+        std::env::set_current_dir(prev).expect("restore cwd");
+        assert!(got.is_none(), "auto-discovery should return None when policies/custom does not exist");
+    }
+
+    #[test]
+    fn default_returns_path_when_policies_custom_exists() {
+        let _guard = CWD_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("policies/custom")).expect("mkdir");
+        let prev = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(tmp.path()).expect("set cwd");
+        let got = resolve_custom_policies_dir(None, None);
+        std::env::set_current_dir(prev).expect("restore cwd");
+        assert_eq!(got, Some(PathBuf::from("policies/custom")));
+    }
 }
 
 /// Mem-backed SurrealDB is the only auth store we can stand up synchronously


### PR DESCRIPTION
## Summary

`schemaforge serve` hardcoded `custom_dir: None` in its post-schema-apply Cedar recompile, so any `policies/custom/*.cedar` validated cleanly via `schemaforge policies validate` but was silently ignored by the running daemon. Row-level forbid policies (the documented mechanism for cross-entity / per-row authorization) never fired. Confirmed in v0.27.0 (Meridian prod pin) and v0.30.0 (HEAD).

## Changes

- New `--custom-dir <DIR>` flag on `serve` (mirrors `policies validate`).
- New `[schema_forge.authz] custom_policies_dir` config key.
- Resolution precedence: CLI flag > config > auto-discover `policies/custom` (only when it exists).
- Threaded through `build_init`, the post-schema-apply recompile, and the `ForgeActor` so runtime schema mutations also recompile against the merged bundle (without it, a schema POST would silently strip custom policies).
- Startup logs `Cedar bundle loaded: N policies, hash XXXX (custom: <dir>)` so misconfiguration is visible.
- Explicit-but-missing directory triggers a warn line; auto-discover defaults stay silent.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo nextest run --workspace` — 1670 passed, 4 skipped
- [x] New regression tests:
  - `resolve_custom_policies_dir` precedence (CLI > config > default-exists / default-absent / explicit-missing-pass-through)
  - `recompile_from_schemas_merges_custom_dir` — proves a custom forbid grows the bundle and changes the hash

## Out of scope

The schema-mutation preflight in `routes/schemas.rs` still passes `None` to `from_schemas`; that path only previews "would this schema change validate?" against generated policies, and a separate issue should track teaching it to consult the same custom bundle. The runtime-effective recompile in this PR is the one that decides production authz.

Fixes #57