### PR TITLE
chore(release): bump cli 0.32.0, acton 0.31.0, backend 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "schema-forge-acton"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "acton-service",
  "arc-swap",
@@ -7197,7 +7197,7 @@ dependencies = [
 
 [[package]]
 name = "schema-forge-backend"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "acton-service",
  "argon2",
@@ -7211,7 +7211,7 @@ dependencies = [
 
 [[package]]
 name = "schema-forge-cli"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "acton-service",
  "assert_cmd",

--- a/crates/schema-forge-acton/Cargo.toml
+++ b/crates/schema-forge-acton/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-forge-acton"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/schema-forge-backend/Cargo.toml
+++ b/crates/schema-forge-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-forge-backend"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-forge-cli"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary
Release bump rolling up the production-audit gap PRs (#61, #62, #63, #64).

| crate | from | to | reason |
|---|---|---|---|
| schema-forge-backend | 0.11.0 | **0.12.0** | breaking: `AuthStore::record_login` required method (#61) |
| schema-forge-acton | 0.30.0 | **0.31.0** | breaking: `DynAuthStore::record_login` shim + `filter_entity_fields` return type change (#61, #63) |
| schema-forge-cli | 0.31.0 | **0.32.0** | follows acton/backend; user-facing audit-emission behaviour |

Pre-1.0 minor bumps per CHANGELOG convention. Release tag will be `v0.32.0` after merge.

## Test plan
- [x] `cargo update -w` clean
- [x] `cargo check --workspace --features schema-forge-acton/surrealdb` clean
- [ ] CI smoke (auto)