### PR TITLE
fix(deps): forward-port acton-service 0.27.0 to main (phantom auth.login.failed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198d5252b1832e28c3df3f75550bd67bd1f7e6f6b2a0e282eac17a1b67aa8aff"
+checksum = "e89c5c01b5ed57c23fcb04ce5b54db69e5af8be3aa981dcb2396f4ece9faf59e"
 dependencies = [
  "acton-reactive",
  "anyhow",

--- a/crates/schema-forge-acton/Cargo.toml
+++ b/crates/schema-forge-acton/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["sync"] }
-acton-service = { version = "0.26.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.27.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 schema-forge-dsl = { path = "../schema-forge-dsl" }
 schema-forge-surrealdb = { path = "../schema-forge-surrealdb", optional = true }
 schema-forge-postgres = { path = "../schema-forge-postgres", optional = true }

--- a/crates/schema-forge-backend/Cargo.toml
+++ b/crates/schema-forge-backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.12.0"
 edition = "2021"
 
 [dependencies]
-acton-service = { version = "0.26.1", default-features = false, features = ["crypto-aws-lc-rs"] }
+acton-service = { version = "0.27.0", default-features = false, features = ["crypto-aws-lc-rs"] }
 argon2 = { version = "0.5", features = ["std"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 schema-forge-core = { path = "../schema-forge-core" }

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -27,7 +27,7 @@ console = "0.15"
 dialoguer = "0.11"
 glob = "0.3"
 axum = { version = "0.8" }
-acton-service = { version = "0.26.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.27.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 heck = "0.5.0"
 minijinja = "2.19.0"
 tracing = "0.1.44"


### PR DESCRIPTION
## Summary

Re-lands the #66/#69 fix onto `main`. PR #69 ("bump acton-service to 0.27.0", closes #66) was merged into the `dev` branch and **never reached `main`**, so production (which ships from `main`) still pins the buggy `acton-service 0.26.1`.

This is a cherry-pick of the proven commit (`f06a1a4`).

## The bug being fixed

The PASETO/JWT middleware in acton-service ≤0.26.1 emitted `AuditEventKind::AuthLoginFailed` on **every unauthenticated request** — turning ALB health-check traffic into 5,760+ false login-failure events per day per instance, drowning out real failed-login signal. Fixed upstream in Govcraft/acton-service#13, released as 0.27.0.

## Change

Bumps the `acton-service` pin `0.26.1 → 0.27.0` across the three crates that depend on it (acton, backend, cli). No API changes required. 0.27.0 is the current latest release.

## Verification

- `cargo check --workspace`: clean; lockfile resolves to a single `acton-service 0.27.0` (no stray 0.26.1).
- `cargo clippy --workspace --all-targets`: 0 warnings.
- `cargo nextest run -p schema-forge-acton -p schema-forge-backend -p schema-forge-cli`: **880 passed**.
- A pre-existing, unrelated flaky/deterministic failure in `schema-forge-dsl::proptest_dsl::valid_minimal_schema_always_parses` (generator emits the reserved keyword `is` as a field name) is tracked separately — it is independent of this change (that crate does not link acton-service and is byte-identical to `main`).

Closes #66.