### PR TITLE
fix(dsl): derive proptest field-name filter from shared keyword sources

### DIFF
--- a/crates/schema-forge-dsl/src/token.rs
+++ b/crates/schema-forge-dsl/src/token.rs
@@ -130,6 +130,35 @@ pub enum Token {
     Ident,
 }
 
+/// Every reserved keyword in the SchemaDSL lexer, as its source string.
+///
+/// Single source of truth for "which identifiers the lexer claims as a keyword
+/// token rather than [`Token::Ident`]". A name listed here cannot be used as a
+/// bare identifier (schema name, field name, etc.) because the lexer never
+/// emits `Ident` for it. Consumers that generate identifiers — notably the
+/// property tests — filter against this list so they can't drift from the
+/// lexer. The `keywords_const_matches_lexer` test pins each entry to a real
+/// keyword token.
+pub const KEYWORDS: &[&str] = &[
+    "schema",
+    "text",
+    "richtext",
+    "integer",
+    "float",
+    "boolean",
+    "datetime",
+    "enum",
+    "json",
+    "composite",
+    "file",
+    "required",
+    "indexed",
+    "unique",
+    "default",
+    "true",
+    "false",
+];
+
 impl Token {
     /// Returns a human-readable description of this token kind.
     pub fn description(&self) -> &'static str {
@@ -209,6 +238,37 @@ mod tests {
                 Token::False,
             ]
         );
+    }
+
+    #[test]
+    fn keywords_const_matches_lexer() {
+        // Every entry in KEYWORDS must lex as exactly one non-`Ident` keyword
+        // token. This pins the published list to the lexer so the two cannot
+        // drift apart silently.
+        for kw in KEYWORDS {
+            let mut lexer = Token::lexer(kw);
+            let tok = lexer
+                .next()
+                .unwrap_or_else(|| panic!("{kw} produced no token"))
+                .unwrap_or_else(|_| panic!("{kw} produced a lex error"));
+            assert_ne!(
+                tok,
+                Token::Ident,
+                "{kw} is in KEYWORDS but the lexer treats it as an identifier"
+            );
+            assert!(lexer.next().is_none(), "{kw} should lex to a single token");
+        }
+    }
+
+    #[test]
+    fn lex_keywords_covers_full_const() {
+        // The `keywords()` test asserts the exact token order for the full
+        // keyword set; this guards that it stays in lockstep with the count of
+        // published KEYWORDS, so a new keyword can't be added to one without
+        // the other.
+        let tokens = lex(&KEYWORDS.join(" "));
+        assert_eq!(tokens.len(), KEYWORDS.len());
+        assert!(tokens.iter().all(|t| *t != Token::Ident));
     }
 
     #[test]

--- a/crates/schema-forge-dsl/tests/proptest_dsl.proptest-regressions
+++ b/crates/schema-forge-dsl/tests/proptest_dsl.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f402f5317d732da796777426d606c8f42b97b065e29545afa6cc382abc869395 # shrinks to name = "A", field = "is", ft = "text"

--- a/crates/schema-forge-dsl/tests/proptest_dsl.rs
+++ b/crates/schema-forge-dsl/tests/proptest_dsl.rs
@@ -1,5 +1,23 @@
 use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use schema_forge_core::types::cedar_reserved::reserved_field_name;
+use schema_forge_dsl::token::KEYWORDS;
 use schema_forge_dsl::{parse, print};
+
+/// Path (relative to the crate root) where proptest persists regression seeds.
+///
+/// Set explicitly because the default `SourceParallel` strategy can't locate a
+/// crate root from an integration test (there is no `lib.rs`/`main.rs` under
+/// `tests/`), which otherwise prints a warning and drops discovered seeds.
+const REGRESSIONS_FILE: &str = "tests/proptest_dsl.proptest-regressions";
+
+/// Proptest configuration with deterministic on-disk seed persistence.
+fn config() -> ProptestConfig {
+    ProptestConfig {
+        failure_persistence: Some(Box::new(FileFailurePersistence::Direct(REGRESSIONS_FILE))),
+        ..ProptestConfig::default()
+    }
+}
 
 /// Strategy for generating valid PascalCase schema names.
 fn pascal_case_name() -> impl Strategy<Value = String> {
@@ -7,26 +25,17 @@ fn pascal_case_name() -> impl Strategy<Value = String> {
 }
 
 /// Strategy for generating valid snake_case field names.
+///
+/// A name is only valid as a bare field identifier if it is neither a DSL
+/// lexer keyword (it would tokenize as a keyword, not an identifier) nor a
+/// Cedar-reserved name (rejected by `FieldName::new`, since field names become
+/// Cedar attribute identifiers). Both exclusion sets are imported from their
+/// owning crates — `schema_forge_dsl::token::KEYWORDS` and
+/// `schema_forge_core`'s `reserved_field_name` — so this filter can never
+/// drift from the parser's actual acceptance criteria.
 fn snake_case_name() -> impl Strategy<Value = String> {
-    "[a-z][a-z0-9_]{0,15}".prop_filter("not a keyword", |s| {
-        !matches!(
-            s.as_str(),
-            "text"
-                | "richtext"
-                | "integer"
-                | "float"
-                | "boolean"
-                | "datetime"
-                | "enum"
-                | "json"
-                | "composite"
-                | "required"
-                | "indexed"
-                | "default"
-                | "true"
-                | "false"
-                | "schema"
-        )
+    "[a-z][a-z0-9_]{0,15}".prop_filter("not a reserved keyword", |s| {
+        !KEYWORDS.contains(&s.as_str()) && reserved_field_name(s).is_none()
     })
 }
 
@@ -44,6 +53,8 @@ fn simple_type() -> impl Strategy<Value = String> {
 }
 
 proptest! {
+    #![proptest_config(config())]
+
     /// Parsing a valid minimal schema should never fail.
     #[test]
     fn valid_minimal_schema_always_parses(


### PR DESCRIPTION
## Summary

Fixes the deterministic failure in `schema-forge-dsl::proptest_dsl::valid_minimal_schema_always_parses` reported in #76.

The property test's `snake_case_name()` strategy maintained a hand-written reserved-word exclusion list that covered DSL lexer keywords but **omitted the Cedar-reserved field names** (`is`, `in`, `has`, `like`, `when`, `unless`, `action`, `context`, `principal`, `resource`, …). The generator therefore produced `schema A { is: text }`, which `FieldName::new` correctly rejects — field names become Cedar attribute identifiers — and the test reported a parse failure for what it believed was a valid schema.

## Changes

- **Single source of truth for lexer keywords.** Export `schema_forge_dsl::token::KEYWORDS`, pinned to the actual `#[token]` set by two new lexer tests (`keywords_const_matches_lexer`, `lex_keywords_covers_full_const`).
- **Reuse the existing Cedar source of truth.** The proptest filter now rejects candidates that are in `KEYWORDS` **or** that `schema_forge_core::types::cedar_reserved::reserved_field_name` flags. The two lists can no longer drift from the parser's real acceptance criteria.
- **Seed-persistence fix (secondary issue).** Set `failure_persistence` to a `Direct` path so proptest stops emitting `failed to find lib.rs or main.rs` and reliably persists regression seeds for this integration test. The discovered seed is checked in.

## Verification

```
cargo nextest run -p schema-forge-dsl   # 239 passed, 0 failed
cargo clippy -p schema-forge-dsl --all-targets   # clean
```

No persistence warning remains. Production code is unaffected (parser behavior unchanged); this was a test-only bug.

Closes #76.