### PR TITLE
fix(surrealdb): resolve __display siblings by matching Thing-typed id (closes #87)

### DIFF
--- a/crates/schema-forge-acton/tests/integration.rs
+++ b/crates/schema-forge-acton/tests/integration.rs
@@ -1322,8 +1322,8 @@ async fn put_missing_required_field_suggests_patch() {
 /// Applies migrations and stores metadata so the backend has live tables.
 async fn setup_paired_schemas() -> (AppState<SchemaForgeConfig>, Router) {
     use schema_forge_core::types::{
-        Cardinality, FieldDefinition, FieldModifier, FieldName, FieldType, SchemaDefinition,
-        SchemaId, SchemaName, TextConstraints,
+        Annotation, Cardinality, FieldDefinition, FieldModifier, FieldName, FieldType,
+        SchemaDefinition, SchemaId, SchemaName, TextConstraints,
     };
 
     let backend = SurrealBackend::connect_memory("test", "test")
@@ -1348,7 +1348,11 @@ async fn setup_paired_schemas() -> (AppState<SchemaForgeConfig>, Router) {
                 },
             ),
         ],
-        vec![],
+        // `@display("title")` so a relation_one → Opportunity resolves a
+        // `<field>__display` sibling (regression coverage for #87).
+        vec![Annotation::Display {
+            field: FieldName::new("title").unwrap(),
+        }],
     )
     .unwrap();
 
@@ -1510,6 +1514,70 @@ async fn derived_collection_populated_on_list() {
         let docs = entity["fields"]["documents"].as_array().unwrap();
         assert_eq!(docs.len(), 2, "each parent should see its two children");
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relation_one_display_sibling_resolves_on_surrealdb() {
+    // Regression for #87: `Document.opportunity` is relation_one → Opportunity,
+    // and Opportunity carries `@display("title")`. On the SurrealDB backend the
+    // display-resolve query filtered the target table with `id IN ['…']`, which
+    // never matched the Thing-typed `id`, so `opportunity__display` came back
+    // empty. Both single-GET and list must now carry the resolved sibling.
+    let (_state, app) = setup_paired_schemas().await;
+
+    let (status, opp) = json_request(
+        &app,
+        Method::POST,
+        "/schemas/Opportunity/entities",
+        Some(serde_json::json!({ "fields": { "title": "Platform v2.0" } })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let opp_id = opp["id"].as_str().unwrap().to_string();
+
+    let (status, doc) = json_request(
+        &app,
+        Method::POST,
+        "/schemas/Document/entities",
+        Some(serde_json::json!({
+            "fields": { "title": "Spec sheet", "opportunity": opp_id }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let doc_id = doc["id"].as_str().unwrap().to_string();
+
+    // Single GET.
+    let (status, body) = json_request(
+        &app,
+        Method::GET,
+        &format!("/schemas/Document/entities/{doc_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["fields"]["opportunity"].as_str(),
+        Some(opp_id.as_str()),
+        "raw relation id should still be present"
+    );
+    assert_eq!(
+        body["fields"]["opportunity__display"].as_str(),
+        Some("Platform v2.0"),
+        "single GET must carry the resolved __display sibling: {body}"
+    );
+
+    // List.
+    let (status, body) =
+        json_request(&app, Method::GET, "/schemas/Document/entities", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let entities = body["entities"].as_array().unwrap();
+    assert_eq!(entities.len(), 1);
+    assert_eq!(
+        entities[0]["fields"]["opportunity__display"].as_str(),
+        Some("Platform v2.0"),
+        "list must carry the resolved __display sibling: {body}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/schema-forge-surrealdb/src/query.rs
+++ b/crates/schema-forge-surrealdb/src/query.rs
@@ -200,8 +200,10 @@ pub fn filter_to_surql_with_schema(
 }
 
 /// If `path` is a single-segment field on `schema` typed as a relation,
-/// emit the value as a record-link literal. Otherwise fall back to the
-/// generic literal renderer.
+/// emit the value as a record-link literal. The implicit `id` primary key is
+/// handled the same way against the query's own table: SurrealDB's `id` is a
+/// `Thing`, so an `id IN ['…']` comparison against plain string literals never
+/// matches. Other paths fall back to the generic literal renderer.
 fn value_for_path(
     value: &DynamicValue,
     path: &FieldPath,
@@ -210,6 +212,11 @@ fn value_for_path(
     if let Some(schema) = schema {
         let segments: Vec<&str> = path.segments().iter().map(|s| s.as_str()).collect();
         if segments.len() == 1 {
+            // `id` is the implicit primary key (not a declared field), so it
+            // resolves against this schema's own table as a record link.
+            if segments[0] == "id" {
+                return relation_value_literal(value, schema.name.as_str());
+            }
             if let Some(field) = schema.field(segments[0]) {
                 if let FieldType::Relation { target, .. } = &field.field_type {
                     return relation_value_literal(value, target.as_str());
@@ -520,6 +527,48 @@ mod tests {
         assert!(sql.contains("ORDER BY name ASC"));
         assert!(sql.contains("LIMIT 10"));
         assert!(sql.contains("START 0"));
+    }
+
+    #[test]
+    fn id_in_filter_emits_record_links_not_strings() {
+        // Regression for #87: the relation-display resolve query filters the
+        // target table with `id IN [referenced ids]`. SurrealDB's `id` is a
+        // `Thing`, so plain string literals never match and the `__display`
+        // siblings come back empty. `id` is the implicit primary key (not a
+        // declared field), so it must resolve against the query's own table.
+        use schema_forge_core::types::{FieldDefinition, FieldName, SchemaName, TextConstraints};
+
+        let schema = SchemaDefinition::new(
+            SchemaId::new(),
+            SchemaName::new("Project").unwrap(),
+            vec![FieldDefinition::new(
+                FieldName::new("name").unwrap(),
+                FieldType::Text(TextConstraints::unconstrained()),
+            )],
+            vec![],
+        )
+        .expect("schema definition must be valid");
+
+        let q = Query::new(schema.id.clone())
+            .with_projection(vec!["id".to_string(), "name".to_string()])
+            .with_filter(Filter::in_set(
+                FieldPath::single("id"),
+                vec![
+                    DynamicValue::Text("project_01ksrhny5cfqr80wmspkk9rhbn".into()),
+                    DynamicValue::Text("project_02abc".into()),
+                ],
+            ));
+        let sql = query_to_surql_with_schema(&q, "Project", Some(&schema));
+        assert_eq!(
+            sql,
+            "SELECT id, name FROM Project WHERE id IN \
+             [Project:`project_01ksrhny5cfqr80wmspkk9rhbn`, Project:`project_02abc`];"
+        );
+        // Guard against the regressed form (plain string literals).
+        assert!(
+            !sql.contains("'project_01ksrhny5cfqr80wmspkk9rhbn'"),
+            "id filter must not emit a plain string literal: {sql}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #87 — on the SurrealDB backend, every relation field came back as a raw id with no `<field>__display` sibling, so generated `/app/*` sites rendered raw ids instead of the related record's `@display` value.

**Root cause:** `resolve_relation_displays` batch-fetches display values with `id IN [referenced ids]`. SurrealDB's `id` is a `Thing`, but `value_for_path` only emitted a record-link literal for declared `Relation` fields. `id` is the implicit primary key (`schema.field("id")` is `None`), so it fell through to a plain string literal → `id IN ['…']` compared `Thing`-to-string → never matched → empty display map. PostgreSQL (TEXT id) was unaffected.

**Fix:** special-case a single-segment `id` path in `value_for_path` to emit a record-link literal against the query's own table (`schema.name`), so the comparison is `Thing`-to-`Thing`.

## Tests

- **Unit** (`query.rs`): asserts `id IN [...]` renders ``Table:`id``` record-link literals, not plain strings.
- **Integration** (`integration.rs`, live `mem://`): seeds a `relation_one` parent carrying `@display`, then asserts `<field>__display` resolves on both single-GET and list. This is exactly the integration the issue flagged as untested — it fails without the fix.

563/563 tests pass across `schema-forge-surrealdb` + `schema-forge-acton`; clippy clean.

Closes #87