### PR TITLE
feat(serve): embed and serve the ops console at /console

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: write
 
+env:
+  # Pinned schemaforge-console release whose signed `dist` bundle is embedded
+  # into the binary. Bump in lockstep with console changes; the build verifies
+  # this release's keyless signature (identity-pinned) before embedding it.
+  CONSOLE_VERSION: v0.1.0
+
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
@@ -47,8 +53,42 @@ jobs:
       - name: Verify Rust toolchain
         run: rustc --version && cargo --version
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Download + verify the signed console bundle
+        env:
+          # GITHUB_TOKEN can read another OSS repo's releases in the same org.
+          # If schemaforge-console is private, swap for a scoped PAT/app token.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$CONSOLE_VERSION" \
+            --repo Govcraft/schemaforge-console \
+            --pattern 'console-dist-*.tar.gz' \
+            --pattern 'SHA256SUMS' \
+            --pattern 'SHA256SUMS.sig' \
+            --pattern 'SHA256SUMS.pem'
+          # Identity-pinned keyless verification (FAIL-CLOSED): a SHA256SUMS
+          # signed by any other repo/workflow — or a tampered manifest — aborts
+          # the build here. A bare verify-blob (no identity/issuer) is not enough.
+          cosign verify-blob \
+            --certificate SHA256SUMS.pem \
+            --signature SHA256SUMS.sig \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github\.com/Govcraft/schemaforge-console/\.github/workflows/release\.yml@' \
+            SHA256SUMS
+          # Tie the verified manifest to the actual tarball bytes, then extract.
+          sha256sum -c SHA256SUMS
+          mkdir -p console-dist
+          tar -xzf console-dist-*.tar.gz -C console-dist
+
       - name: Build release binary (${{ matrix.backend }} / ${{ matrix.target }})
-        run: cargo build --release --package schema-forge-cli --no-default-features --features ${{ matrix.backend }}
+        env:
+          # Points rust-embed at the verified console bundle (build.rs re-exports
+          # it for the `#[folder = "$SCHEMAFORGE_CONSOLE_DIST"]` interpolation).
+          SCHEMAFORGE_CONSOLE_DIST: ${{ github.workspace }}/console-dist
+        run: cargo build --release --package schema-forge-cli --no-default-features --features ${{ matrix.backend }},embedded-console
 
       - name: Package
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,6 +2559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6923,6 +6932,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
+ "shellexpand",
  "syn 2.0.114",
  "walkdir",
 ]
@@ -7287,9 +7297,11 @@ dependencies = [
  "heck",
  "indicatif",
  "miette 7.6.0",
+ "mime_guess",
  "minijinja",
  "predicates",
  "reqwest 0.13.3",
+ "rust-embed",
  "schema-forge-acton",
  "schema-forge-backend",
  "schema-forge-core",
@@ -7737,6 +7749,15 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -34,6 +34,8 @@ tracing = "0.1.44"
 schema-forge-signing = { version = "0.1.0", path = "../schema-forge-signing" }
 sigstore-trust-root = { version = "0.7.0", default-features = false, features = ["tuf"] }
 reqwest = { version = "0.13.3", default-features = false, features = ["json", "rustls-no-provider"] }
+rust-embed = { version = "8.11.0", features = ["interpolate-folder-path"], optional = true }
+mime_guess = { version = "2.0.5", optional = true }
 
 [features]
 default = ["surrealdb"]
@@ -43,6 +45,11 @@ postgres = ["dep:schema-forge-postgres", "schema-forge-acton/postgres", "acton-s
 # aws-lc-rs compiled against the FIPS-validated AWS-LC C library.
 # Requires cmake + a supported toolchain. See README "FIPS builds".
 fips = ["schema-forge-acton/fips"]
+# Embed the prebuilt ops console (schemaforge-console `dist`) into the binary so
+# `serve` can host it same-origin at `/`. Off by default to keep dev builds fast
+# and Node-free; release CI turns it on after verifying the signed bundle and
+# pointing SCHEMAFORGE_CONSOLE_DIST at it. See build.rs + commands/serve_console.rs.
+embedded-console = ["dep:rust-embed", "dep:mime_guess"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/schema-forge-cli/build.rs
+++ b/crates/schema-forge-cli/build.rs
@@ -38,6 +38,68 @@ fn main() {
     out.push_str("];\n");
 
     fs::write(&dest, out).unwrap();
+
+    resolve_console_dist(&out_dir);
+}
+
+/// Resolve the directory `rust-embed` reads the ops console from, for the
+/// `embedded-console` feature (`commands/serve_console.rs`).
+///
+/// Only active under that feature (cargo exports `CARGO_FEATURE_EMBEDDED_CONSOLE`
+/// for enabled features); otherwise the module is never compiled and this is a
+/// no-op. Resolution:
+///   - `SCHEMAFORGE_CONSOLE_DIST` set -> use it (release CI points this at the
+///     downloaded, signature-verified console `dist`; dev points it at a local
+///     `apps/console/dist`). Must contain `index.html`.
+///   - unset -> write a tiny stub `index.html` into `OUT_DIR` so the feature
+///     still compiles locally without a bundle present.
+///
+/// The resolved path is re-exported via `cargo:rustc-env` so the
+/// `#[folder = "$SCHEMAFORGE_CONSOLE_DIST"]` attribute on `ConsoleAssets`
+/// (rust-embed `interpolate-folder-path`) expands to it during macro expansion.
+fn resolve_console_dist(out_dir: &Path) {
+    println!("cargo:rerun-if-env-changed=SCHEMAFORGE_CONSOLE_DIST");
+    if env::var_os("CARGO_FEATURE_EMBEDDED_CONSOLE").is_none() {
+        return;
+    }
+
+    let dist = match env::var_os("SCHEMAFORGE_CONSOLE_DIST").filter(|p| !p.is_empty()) {
+        Some(p) => {
+            let path = PathBuf::from(&p);
+            assert!(
+                path.join("index.html").is_file(),
+                "SCHEMAFORGE_CONSOLE_DIST={} has no index.html; point it at a built console `dist`",
+                path.display()
+            );
+            println!("cargo:rerun-if-changed={}", path.display());
+            // Absolute so rust-embed resolves it independently of CWD.
+            fs::canonicalize(&path).unwrap_or(path)
+        }
+        None => write_console_stub(out_dir),
+    };
+
+    println!(
+        "cargo:rustc-env=SCHEMAFORGE_CONSOLE_DIST={}",
+        dist.display()
+    );
+}
+
+/// Write a placeholder `dist` into `OUT_DIR` so `--features embedded-console`
+/// compiles even when no bundle was supplied. A binary built this way serves a
+/// short "console not bundled" page instead of the real app.
+fn write_console_stub(out_dir: &Path) -> PathBuf {
+    let stub = out_dir.join("console-stub");
+    fs::create_dir_all(&stub).expect("create console stub dir");
+    fs::write(
+        stub.join("index.html"),
+        "<!doctype html><html><head><meta charset=\"utf-8\">\
+         <title>SchemaForge</title></head><body>\
+         <p>The ops console was not bundled into this build. Rebuild with \
+         <code>--features embedded-console</code> and <code>SCHEMAFORGE_CONSOLE_DIST</code> \
+         pointed at a built console <code>dist</code>.</p></body></html>",
+    )
+    .expect("write stub index.html");
+    stub
 }
 
 fn walk(root: &Path, dir: &Path, out: &mut Vec<(String, PathBuf)>) {

--- a/crates/schema-forge-cli/src/cli.rs
+++ b/crates/schema-forge-cli/src/cli.rs
@@ -741,6 +741,14 @@ pub struct ServeArgs {
     #[arg(long = "dev-cors")]
     pub dev_cors: bool,
 
+    /// Do not serve the bundled ops console, even in a build that embeds it.
+    ///
+    /// The console (when compiled in via the `embedded-console` feature) is
+    /// served same-origin at `/` as the router fallback. Pass this to run the
+    /// JSON API only. No effect on builds without the console embedded.
+    #[arg(long = "no-console")]
+    pub no_console: bool,
+
     /// Path to a `role_ranks.toml` defining the role-name → numeric-rank
     /// hierarchy. The runtime no-upward-visibility guard for user mgmt
     /// (`principal.role_rank >= resource.role_rank`) reads from this file.

--- a/crates/schema-forge-cli/src/commands/mod.rs
+++ b/crates/schema-forge-cli/src/commands/mod.rs
@@ -12,6 +12,8 @@ pub mod migrate;
 pub mod parse;
 pub mod policies;
 pub mod serve;
+#[cfg(feature = "embedded-console")]
+pub mod serve_console;
 pub mod sign;
 pub mod site;
 pub mod token;

--- a/crates/schema-forge-cli/src/commands/serve.rs
+++ b/crates/schema-forge-cli/src/commands/serve.rs
@@ -308,6 +308,14 @@ pub async fn run(
         // possession of a valid, unconsumed invitation, not a bearer.
         pc.public_paths
             .push("/api/v1/forge/auth/invites/accept".to_string());
+        // The bundled ops console (when embedded) is a static SPA served under
+        // `/console`; its shell + assets + client-side routes must load before
+        // the user has a token (they sign in *through* it). The prefix is
+        // disjoint from `/api`, so the JSON API stays bearer-protected.
+        #[cfg(feature = "embedded-console")]
+        if !args.no_console {
+            pc.public_paths.push("/console".to_string());
+        }
     }
 
     // Opt-in permissive CORS for local development. Warns loudly in logs.
@@ -414,10 +422,23 @@ pub async fn run(
     // (e.g. `Config.service.version` or a `with_service_version` builder).
     let routes = wrap_health_with_schema_forge_version(routes);
 
+    // Mount the embedded ops console as the root fallback (served same-origin at
+    // `/`), unless this build omitted it or the operator passed --no-console.
+    #[cfg(feature = "embedded-console")]
+    let routes = if args.no_console {
+        routes
+    } else {
+        mount_console(routes)
+    };
+    let console_served = cfg!(feature = "embedded-console") && !args.no_console;
+
     let bind_addr = format!("{}:{}", args.host, args.port);
     output.success(&format!(
         "SchemaForge server listening on http://{bind_addr}"
     ));
+    if console_served {
+        output.status(&format!("  Console → http://{bind_addr}/console"));
+    }
     output.status("  Routes:");
     output.status("    GET  /health");
     output.status("    GET  /ready");
@@ -724,9 +745,11 @@ fn build_paseto_generator(
 
 /// Build versioned routes using acton-service's VersionedApiBuilder.
 ///
-/// Nests SchemaForge's JSON API routes under `/api/v1/forge/`. All UI
-/// surfaces are generated client-side by `schemaforge site generate`; this
-/// server only serves the JSON API plus the login endpoint.
+/// Nests SchemaForge's JSON API routes under `/api/v1/forge/`, plus the login
+/// endpoint. A build with the `embedded-console` feature additionally serves
+/// the bundled ops console same-origin at `/` (mounted as the router fallback
+/// by [`mount_console`]); `schemaforge site generate` remains available for a
+/// separately-hosted, per-entity React project.
 #[allow(clippy::too_many_arguments)]
 fn build_versioned_routes(
     auth_store: Arc<dyn schema_forge_acton::DynAuthStore>,
@@ -815,6 +838,44 @@ fn build_paseto_validator(
 /// `VersionedApiBuilder::build_routes()` is documented to always return
 /// `WithState`, but we keep the `WithoutState` branch as a defensive
 /// pass-through in case upstream changes the contract.
+/// Mount the embedded ops console under `/console`, served same-origin by
+/// [`crate::commands::serve_console`]. `/console` is registered as a public
+/// path (see `run`) so the static SPA loads before the user has a token; the
+/// prefix is disjoint from `/api`, which stays bearer-protected. Scoping the
+/// console to its own prefix (rather than the router fallback) is what lets a
+/// single public-path entry exempt the whole SPA without exposing the API.
+///
+/// Mirrors [`wrap_health_with_schema_forge_version`]'s `VersionedRoutes`
+/// destructure so it composes through the same `ServiceBuilder::with_routes`
+/// seam without needing acton-service's htmx-gated `with_frontend_routes`.
+#[cfg(feature = "embedded-console")]
+fn mount_console(
+    routes: acton_service::service_builder::VersionedRoutes<schema_forge_acton::SchemaForgeConfig>,
+) -> acton_service::service_builder::VersionedRoutes<schema_forge_acton::SchemaForgeConfig> {
+    use acton_service::service_builder::VersionedRoutes;
+    use axum::routing::get;
+    use crate::commands::serve_console::handler;
+
+    // Three routes cover the SPA: `/console` (no slash), `/console/` (root with
+    // slash), and `/console/{*rest}` (assets + client-side deep links). The
+    // handler strips the `/console` prefix and serves the embedded asset, or
+    // `index.html` for an unknown sub-path (SPA history fallback).
+    fn add<S>(router: axum::Router<S>) -> axum::Router<S>
+    where
+        S: Clone + Send + Sync + 'static,
+    {
+        router
+            .route("/console", get(handler))
+            .route("/console/", get(handler))
+            .route("/console/{*rest}", get(handler))
+    }
+
+    match routes {
+        VersionedRoutes::WithState(router) => VersionedRoutes::WithState(add(router)),
+        VersionedRoutes::WithoutState(router) => VersionedRoutes::WithoutState(add(router)),
+    }
+}
+
 fn wrap_health_with_schema_forge_version(
     routes: acton_service::service_builder::VersionedRoutes<schema_forge_acton::SchemaForgeConfig>,
 ) -> acton_service::service_builder::VersionedRoutes<schema_forge_acton::SchemaForgeConfig> {

--- a/crates/schema-forge-cli/src/commands/serve_console.rs
+++ b/crates/schema-forge-cli/src/commands/serve_console.rs
@@ -1,0 +1,196 @@
+//! Serve the embedded ops console (the `schemaforge-console` `dist`) same-origin
+//! from `serve`, so a non-developer gets a working admin UI by opening the URL
+//! the binary prints — no Node, no build, no CORS.
+//!
+//! Compiled only under the `embedded-console` feature. The console is a
+//! runtime-generic SPA (it discovers schemas/CRUD at runtime), so one bundle
+//! serves any schema. It is mounted as the router's `fallback`, so it only
+//! handles paths the API/health routes don't (`mount_console` in `serve.rs`).
+//!
+//! The routing decision is factored into a pure `route_for` so it is unit-
+//! testable without the embedded bytes (which are whatever `SCHEMAFORGE_CONSOLE_DIST`
+//! held at build time — only `index.html` in a stub build).
+
+use axum::{
+    http::{header, StatusCode, Uri},
+    response::{IntoResponse, Response},
+};
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "$SCHEMAFORGE_CONSOLE_DIST"]
+struct ConsoleAssets;
+
+const INDEX: &str = "index.html";
+
+/// The URL prefix the console is mounted under (see `serve::mount_console`).
+const MOUNT: &str = "/console";
+
+/// Strip the `/console` mount prefix to get the path *within* the SPA.
+///
+/// `/console` and `/console/` both map to the root (`/`); `/console/assets/x`
+/// maps to `/assets/x`. A path outside the mount (shouldn't happen, since the
+/// routes are scoped) maps to `/` so the worst case is the SPA shell.
+fn strip_mount(path: &str) -> &str {
+    match path.strip_prefix(MOUNT) {
+        Some("") => "/",
+        Some(rest) => rest,
+        None => "/",
+    }
+}
+
+/// What to serve for a request path, independent of the embedded bytes.
+#[derive(Debug, PartialEq, Eq)]
+enum Route {
+    /// Serve this exact embedded asset key.
+    Asset(String),
+    /// Serve `index.html` as the SPA history fallback (client-side route).
+    Index,
+    /// Nothing matched and no SPA fallback applies.
+    NotFound,
+}
+
+/// Map a request path to a [`Route`], given a predicate for whether an asset key
+/// exists and whether `index.html` is present.
+///
+/// - `/` (empty) resolves to `index.html`.
+/// - An existing key is served directly.
+/// - A missing key **under `assets/`** is a real 404 (a fingerprinted file that
+///   genuinely isn't there) — never the HTML shell with a JS path.
+/// - Any other missing path is a client-side route → `index.html` (SPA deep link),
+///   when an index exists.
+fn route_for(path: &str, exists: impl Fn(&str) -> bool, has_index: bool) -> Route {
+    let trimmed = path.trim_start_matches('/');
+    let key = if trimmed.is_empty() { INDEX } else { trimmed };
+
+    if exists(key) {
+        return Route::Asset(key.to_string());
+    }
+    if key.starts_with("assets/") {
+        return Route::NotFound;
+    }
+    if has_index {
+        Route::Index
+    } else {
+        Route::NotFound
+    }
+}
+
+/// Cache policy for a served asset. Vite content-hashes everything under
+/// `assets/`, so those are immutable; the HTML shell (index, or any SPA
+/// fallback) must never be cached or a client pins a stale shell after upgrade.
+fn cache_control(key: &str, is_index_fallback: bool) -> &'static str {
+    if !is_index_fallback && key.starts_with("assets/") {
+        "public, max-age=31536000, immutable"
+    } else {
+        "no-cache"
+    }
+}
+
+/// Build the HTTP response for an embedded asset key.
+fn asset_response(key: &str, bytes: Vec<u8>, is_index_fallback: bool) -> Response {
+    let mime = mime_guess::from_path(key).first_or_octet_stream();
+    (
+        [
+            (header::CONTENT_TYPE, mime.as_ref().to_string()),
+            (
+                header::CACHE_CONTROL,
+                cache_control(key, is_index_fallback).to_string(),
+            ),
+        ],
+        bytes,
+    )
+        .into_response()
+}
+
+/// Resolve a request path to a response over the embedded console assets.
+pub fn serve_asset(path: &str) -> Response {
+    let has_index = ConsoleAssets::get(INDEX).is_some();
+    match route_for(path, |k| ConsoleAssets::get(k).is_some(), has_index) {
+        Route::Asset(key) => {
+            let data = ConsoleAssets::get(&key)
+                .expect("asset existed in route_for predicate")
+                .data
+                .into_owned();
+            asset_response(&key, data, false)
+        }
+        Route::Index => {
+            let data = ConsoleAssets::get(INDEX)
+                .expect("has_index implies index present")
+                .data
+                .into_owned();
+            asset_response(INDEX, data, true)
+        }
+        Route::NotFound => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}
+
+/// axum handler for the `/console{,/,/*rest}` routes: strip the mount prefix
+/// and serve the corresponding embedded asset (or the SPA shell).
+pub async fn handler(uri: Uri) -> Response {
+    serve_asset(strip_mount(uri.path()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_exists(key: &str) -> bool {
+        matches!(key, "index.html" | "assets/app-abc123.js")
+    }
+
+    #[test]
+    fn root_resolves_to_index() {
+        assert_eq!(
+            route_for("/", fake_exists, true),
+            Route::Asset("index.html".to_string())
+        );
+    }
+
+    #[test]
+    fn existing_asset_is_served_directly() {
+        assert_eq!(
+            route_for("/assets/app-abc123.js", fake_exists, true),
+            Route::Asset("assets/app-abc123.js".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_route_falls_back_to_index() {
+        // A client-side deep link (no such file) → SPA shell.
+        assert_eq!(route_for("/Contact/abc", fake_exists, true), Route::Index);
+    }
+
+    #[test]
+    fn missing_asset_is_not_found_not_index() {
+        // A fingerprinted asset that isn't there must 404, not return HTML.
+        assert_eq!(
+            route_for("/assets/missing.js", fake_exists, true),
+            Route::NotFound
+        );
+    }
+
+    #[test]
+    fn no_index_means_not_found() {
+        assert_eq!(route_for("/anything", |_| false, false), Route::NotFound);
+    }
+
+    #[test]
+    fn strip_mount_maps_console_prefix_to_spa_path() {
+        assert_eq!(strip_mount("/console"), "/");
+        assert_eq!(strip_mount("/console/"), "/");
+        assert_eq!(strip_mount("/console/assets/app-abc123.js"), "/assets/app-abc123.js");
+        assert_eq!(strip_mount("/console/Contact/abc"), "/Contact/abc");
+    }
+
+    #[test]
+    fn assets_get_immutable_cache_html_does_not() {
+        assert_eq!(
+            cache_control("assets/app-abc123.js", false),
+            "public, max-age=31536000, immutable"
+        );
+        assert_eq!(cache_control("index.html", false), "no-cache");
+        // An SPA fallback that happens to resolve a non-asset key is still HTML.
+        assert_eq!(cache_control("index.html", true), "no-cache");
+    }
+}

--- a/docs/site-guide.md
+++ b/docs/site-guide.md
@@ -2,6 +2,28 @@
 
 `schemaforge site generate` scaffolds a Vite + React 19 + Tailwind 4 + shadcn project that talks to a running `schemaforge serve` instance over `/api/v1/forge/*`. This guide is the starting point for anyone who wants to ship a UI on top of their schemas.
 
+## Two ways to get a UI
+
+1. **Bundled ops console — zero config.** A release binary built with the `embedded-console` feature serves the prebuilt [`schemaforge-console`](https://github.com/Govcraft/schemaforge-console) SPA same-origin at **`/console`** — no Node, no build step, no CORS. Just run the server and open the `Console → http://<host>/console` URL it prints, then sign in with the `--admin-user` / `--admin-password` credentials:
+
+   ```bash
+   schemaforge serve --schemas schemas --admin-password <pw>
+   # → Console → http://127.0.0.1:3000/console
+   ```
+
+   The console is schema-generic (it discovers your schemas at runtime via `/api/v1/forge/schemas`), so one bundle works for any schema — there is nothing to regenerate per schema. Pass `--no-console` to run the JSON API only; a binary built without the `embedded-console` feature also serves the API alone.
+
+   Building from source with the console embedded (release CI verifies a signed bundle; locally, point at a built `dist`):
+
+   ```bash
+   pnpm --filter @schemaforge/console build      # in the schemaforge-console checkout
+   SCHEMAFORGE_CONSOLE_DIST=/path/to/schemaforge-console/apps/console/dist \
+     cargo run -p schema-forge-cli --features embedded-console -- \
+     serve --schemas schemas --admin-password <pw>
+   ```
+
+2. **Generated project — fully customizable.** `schemaforge site generate` scaffolds a Vite + React project with strongly-typed, per-entity pages that you restyle and host yourself. The rest of this guide covers that path.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary
Serve the prebuilt `schemaforge-console` SPA same-origin under **`/console`**, behind the new `embedded-console` cargo feature (off by default). A non-developer gets an admin UI by opening the URL the binary prints — no Node, no build step, no CORS.

## How
- **`build.rs`** resolves `SCHEMAFORGE_CONSOLE_DIST` (or an `OUT_DIR` stub) and re-exports it for `rust-embed`'s `$`-interpolated folder.
- **`commands/serve_console.rs`** (new): `rust-embed` assets + a pure, unit-tested `route_for`/`strip_mount`/`cache_control` core — immutable cache for `/assets`, `no-cache` HTML, SPA `index.html` fallback, 404 for missing fingerprinted assets.
- **`serve.rs`** `mount_console` registers `/console{,/,/*rest}`; `/console` is added to the PASETO public paths so the static SPA loads pre-auth while `/api` stays bearer-protected. (acton-service's prefix-allowlist can't express a root mount without exposing `/api` — hence `/console`.)
- `--no-console` opt-out; startup banner prints the console URL.
- **`release.yml`** downloads the pinned `schemaforge-console` bundle, verifies its **keyless cosign signature (identity-pinned, fail-closed)** + sha256, then builds with the feature.
- Docs updated (`site-guide.md`): bundled console vs `site generate`.

## Verification
- `cargo clippy` clean with the feature **on and off**; 7 `serve_console` unit tests pass.
- End-to-end against a live `mem://` backend: login → schema-driven nav (18 schemas, proving the token reaches the protected `/api` same-origin) → entity list renders; `/console*` public + correct content-types/cache; `/api` still 401 without a token; missing assets 404; SPA deep-links fall back to index; 0 console errors.

## Notes / follow-ups
- `CONSOLE_VERSION` in `release.yml` is a placeholder (`v0.1.0`) — the console repo has no releases yet; bump once it publishes a signed `v*` tag. The two repos are release-coupled by design.
- Cross-repo download uses `GITHUB_TOKEN` (works for a public console repo; swap for a scoped token if private).