### PR TITLE
feat(demo): CONSOLE=1 embeds + serves the ops console at /console

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,6 +20,11 @@ vars:
   SITE_DIR: site
   SCHEMA_DIR: schemas
   SITE_DEV_PORT: 5173
+  # Release config for the embedded ops console (read by the `demo` task when
+  # the CONSOLE env var is set — see below).
+  CONSOLE_VERSION: v0.1.0
+  CONSOLE_REPO: Govcraft/schemaforge-console
+  CONSOLE_IDENTITY: '^https://github\.com/Govcraft/schemaforge-console/\.github/workflows/release\.yml@'
 
 tasks:
   build:
@@ -53,13 +58,60 @@ tasks:
       BASE_URL: "{{.BASE_URL}}"
 
   demo:
-    desc: Build, start server with in-memory DB, seed demo data, then keep running
+    desc: "Build, start server (in-memory DB), seed demo data, then keep running. CONSOLE=1 also serves the ops console at /console."
     cmds:
       - |
         set -euo pipefail
 
+        # CONSOLE is a real environment variable read by this shell (not a
+        # go-task var), so `CONSOLE=1 task demo` works. Set it to embed + serve
+        # the ops console at /console.
+        CONSOLE="${CONSOLE:-}"
+        FEATURES="{{.FEATURES}}"
+
+        # Base feature args (backend selection).
+        feature_args=""
+        if [ -n "$FEATURES" ]; then
+          feature_args="--no-default-features --features $FEATURES"
+        fi
+
+        # CONSOLE=1: fetch + verify the signed console bundle, then add the
+        # embedded-console feature so `serve` mounts it at /console. This mirrors
+        # the release pipeline (download → identity-pinned cosign verify → sha256
+        # → embed), so it also exercises the supply-chain path locally.
+        if [ "$CONSOLE" = "1" ]; then
+          for tool in gh cosign; do
+            command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: CONSOLE=1 needs '$tool' on PATH."; exit 1; }
+          done
+          console_dist="$PWD/target/console-dist"
+          echo "Fetching signed console bundle {{.CONSOLE_VERSION}} from {{.CONSOLE_REPO}}..."
+          tmp="$(mktemp -d)"
+          gh release download "{{.CONSOLE_VERSION}}" --repo "{{.CONSOLE_REPO}}" \
+            --pattern 'console-dist-*.tar.gz' --pattern 'SHA256SUMS' \
+            --pattern 'SHA256SUMS.sig' --pattern 'SHA256SUMS.pem' \
+            --dir "$tmp" --clobber
+          # Identity-pinned keyless verification — fails closed if the bundle was
+          # signed by any other repo/workflow, or the manifest was tampered.
+          cosign verify-blob \
+            --certificate "$tmp/SHA256SUMS.pem" --signature "$tmp/SHA256SUMS.sig" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '{{.CONSOLE_IDENTITY}}' \
+            "$tmp/SHA256SUMS"
+          ( cd "$tmp" && sha256sum -c SHA256SUMS )
+          rm -rf "$console_dist" && mkdir -p "$console_dist"
+          tar -xzf "$tmp"/console-dist-*.tar.gz -C "$console_dist"
+          rm -rf "$tmp"
+          export SCHEMAFORGE_CONSOLE_DIST="$console_dist"
+          if [ -n "$FEATURES" ]; then
+            feature_args="--no-default-features --features ${FEATURES},embedded-console"
+          else
+            feature_args="--features embedded-console"
+          fi
+          echo "Verified console bundle -> $console_dist"
+        fi
+
         # Build the CLI
-        cargo build -p schema-forge-cli {{if .FEATURES}}--no-default-features --features {{.FEATURES}}{{end}}
+        cargo build -p schema-forge-cli $feature_args
 
         # Start server in background with in-memory DB.
         # `--config config.toml` is explicit so the project's [rate_limit]
@@ -106,8 +158,14 @@ tasks:
         echo "    meta:      {{.BASE_URL}}/api/v1/forge/meta"
         echo "    schemas:   {{.BASE_URL}}/api/v1/forge/schemas"
         echo ""
-        echo "  Launch the React app site:"
-        echo "    task site:dev   # regenerates site/ and starts Vite on :{{.SITE_DEV_PORT}}"
+        if [ "$CONSOLE" = "1" ]; then
+          echo "  Ops console (embedded, served same-origin):"
+          echo "    {{.BASE_URL}}/console"
+        else
+          echo "  Launch the React app site:"
+          echo "    task site:dev          # regenerates site/ and starts Vite on :{{.SITE_DEV_PORT}}"
+          echo "    CONSOLE=1 task demo    # or embed + serve the ops console at /console"
+        fi
         echo ""
         echo "  Press Ctrl+C to stop the backend."
         echo "============================================================"


### PR DESCRIPTION
Adds a `CONSOLE=1` toggle to `task demo` that serves the embedded ops console at `/console` alongside the API, the **release-faithful** way:

1. `gh release download` the pinned `schemaforge-console` release (`CONSOLE_VERSION=v0.1.0`)
2. `cosign verify-blob` — **identity-pinned, fail-closed** (same check the binary's release build runs)
3. `sha256sum -c`
4. extract → `SCHEMAFORGE_CONSOLE_DIST`, build with `--features embedded-console`

So it also exercises the supply-chain path locally. Without `CONSOLE=1`, `task demo` is unchanged (backend only).

`CONSOLE` is read from the **shell environment** (`${CONSOLE:-}`), not a go-task var, because go-task `vars:` defaults take precedence over OS env — so `CONSOLE=1 task demo` works (verified), while `{{.CONSOLE}}` would not have. Needs `gh` + `cosign` on PATH.

## Verified
`CONSOLE=1 task demo PORT=3057`: `Fetching signed console bundle v0.1.0` → `cosign Verified OK` → `console-dist-v0.1.0.tar.gz: OK` → `Console → …/console`; `/console` 200 (no auth), `/api` 401.