### PR TITLE
Release v0.34.0 (cli 0.34.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "schema-forge-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "acton-service",
  "assert_cmd",

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-forge-cli"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 
 [[bin]]

--- a/skills/schemaforge/SKILL.md
+++ b/skills/schemaforge/SKILL.md
@@ -9,7 +9,7 @@ description: Use when writing, creating, editing, or reviewing SchemaForge .sche
 
 SchemaForge is an Adaptive Object Model runtime with a human-readable DSL. One `.schema` file produces database tables, REST API endpoints, migrations, Cedar authorization policies, and OpenAPI specs — no recompilation required.
 
-**Version:** 0.33.0
+**Version:** 0.34.0
 
 **Core principle:** Schemas are the single source of truth for the entire entity lifecycle. Authorization is **Cedar-canonical**: every read/write/delete decision flows through the embedded Cedar engine — there are no parallel custom guards.
 


### PR DESCRIPTION
Release bump for **v0.34.0**: built-in declarative CEL rules engine (epic #89) + embedded ops-console. Bumps `schema-forge-cli` 0.33.0 → 0.34.0 (the product/tag version); other crates were bumped in their feature commits. Tag pushed after merge triggers the multi-platform release build.