### PR TITLE
acton-service 0.34.1 upgrade + schemaforge skill acton-service gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.27.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89c5c01b5ed57c23fcb04ce5b54db69e5af8be3aa981dcb2396f4ece9faf59e"
+checksum = "90f16b067374834c7c2879acc85ff4977b71fa19f5980ff09a9fb9d1c890d0a2"
 dependencies = [
  "acton-reactive",
  "anyhow",
@@ -78,6 +78,7 @@ dependencies = [
  "mti",
  "once_cell",
  "opentelemetry",
+ "opentelemetry-instrumentation-tower",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prost-build",
@@ -94,12 +95,11 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tonic 0.14.5",
+ "tonic",
  "tonic-build",
  "tonic-prost-build",
  "tower",
  "tower-http",
- "tower-otel-http-metrics",
  "tower-resilience-bulkhead",
  "tower-resilience-circuitbreaker",
  "tracing",
@@ -5308,9 +5308,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5322,9 +5322,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5334,41 +5334,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-otlp"
-version = "0.30.0"
+name = "opentelemetry-instrumentation-tower"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "5fa342b7ded339a38c6df9a3aef833298bca24a7aeec098397b4b3ec741b0e52"
+dependencies = [
+ "axum",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.5",
+ "prost",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.13.1",
+ "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.13.1",
+ "prost",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -5376,7 +5400,6 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
- "serde_json",
  "thiserror 2.0.18",
 ]
 
@@ -6022,22 +6045,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -6052,26 +6065,13 @@ dependencies = [
  "multimap",
  "petgraph 0.8.3",
  "prettyplease",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.114",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6093,7 +6093,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-types",
 ]
 
@@ -6103,7 +6103,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -7266,7 +7266,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "lettre",
- "prost 0.14.3",
+ "prost",
  "prost-build",
  "prost-reflect",
  "reqwest 0.13.3",
@@ -7287,7 +7287,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 1.1.2+spec-1.1.0",
- "tonic 0.14.5",
+ "tonic",
  "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
@@ -7318,7 +7318,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "chrono-tz",
- "prost 0.14.3",
+ "prost",
  "prost-build",
  "prost-types",
  "regex",
@@ -8857,13 +8857,13 @@ dependencies = [
  "flatbuffers",
  "futures",
  "geo 0.32.0",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "rust_decimal",
  "semver",
  "serde",
  "serde_json",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "uuid",
 ]
@@ -9476,32 +9476,6 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -9549,8 +9523,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -9656,25 +9630,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-otel-http-metrics"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1dde2214d51e31911933b312d69dd1dcc30cc9d5e1a77734191fffb23d248e"
-dependencies = [
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "opentelemetry",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-resilience-bulkhead"
-version = "0.4.7"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c9b15e771d70a9b12318549faa7e2bb2ebe519904157d4f273112685286749"
+checksum = "954ebc262351e20f2cbd76b916ce59d887fb32ce0e579061c8c24f17e5a68411"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -9687,9 +9646,9 @@ dependencies = [
 
 [[package]]
 name = "tower-resilience-circuitbreaker"
-version = "0.4.7"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff16e1f78dfac712d37e9332d23a4066d3fa8ccd82e8ba131a49018e594751f8"
+checksum = "62dfa8324283dd6ce8102ae60be686e0849ff2a0bd182c80d8ccb0f5fd55f118"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -9700,9 +9659,9 @@ dependencies = [
 
 [[package]]
 name = "tower-resilience-core"
-version = "0.4.7"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd405f5badae6282b44de3278f5c1f9098865cc348fbc9218babd777721cf16b"
+checksum = "756171904b6fe320288e48b3741a5ea9490006f17734091b883f340d1e1e28af"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -9783,14 +9742,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/crates/schema-forge-acton/Cargo.toml
+++ b/crates/schema-forge-acton/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["sync"] }
-acton-service = { version = "0.27.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.34.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 schema-forge-dsl = { path = "../schema-forge-dsl" }
 schema-forge-surrealdb = { path = "../schema-forge-surrealdb", optional = true }
 schema-forge-postgres = { path = "../schema-forge-postgres", optional = true }

--- a/crates/schema-forge-backend/Cargo.toml
+++ b/crates/schema-forge-backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [dependencies]
-acton-service = { version = "0.27.0", default-features = false, features = ["crypto-aws-lc-rs"] }
+acton-service = { version = "0.34.1", default-features = false, features = ["crypto-aws-lc-rs"] }
 argon2 = { version = "0.5", features = ["std"] }
 async-trait = "0.1.89"
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -27,7 +27,7 @@ console = "0.15"
 dialoguer = "0.11"
 glob = "0.3"
 axum = { version = "0.8" }
-acton-service = { version = "0.27.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.34.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 heck = "0.5.0"
 minijinja = "2.19.0"
 tracing = "0.1.44"

--- a/skills/schemaforge/SKILL.md
+++ b/skills/schemaforge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schemaforge
-description: Use when writing, creating, editing, or reviewing SchemaForge .schema files. Use when defining data models, entity schemas, field types (incl. `duration`, `bytes`, and `map<text, V>`), relations, access control, or multi-tenant hierarchies in the SchemaForge DSL syntax. Use when declaring write-time validation, computed fields, or computed defaults via the CEL rule annotations `@require` / `@compute` / `@default` (in-process, fail-closed, no gRPC), including single-hop cross-entity reads (`related.<field>.<col>`) inside `@require`. Use when declaring `unique` field constraints (per-tenant for `@tenant(...)` schemas, table-wide otherwise) and handling the 409 `unique_violation` error path. Use when declaring `file` fields backed by S3-compatible storage (MinIO, AWS S3, R2, Wasabi), configuring `[schema_forge.storage]` backends, or wiring upload/download/scan flows. Use when scaffolding or regenerating the React site with `schema-forge site generate`, wiring the `/app/*` per-entity pages or the runtime-dynamic `/admin/*` shell, or iterating with the `--templates-dir` override loader. Use when querying entities via the REST API, filtering, sorting, pagination, or building query parameters. Use when declaring lifecycle hooks via @hook annotations (including `before_upload`, `after_upload`, `on_scan_complete` for file fields), scaffolding hook gRPC services with `schema-forge hooks generate`, configuring [schema_forge.hooks] bindings, or auditing hooks with `hooks list` / `hooks diff`. Use when hitting `/api/v1/forge/auth/login`, `/auth/refresh`, or `/api/v1/forge/users` for the PASETO bootstrap and user management flows. Use when mapping PASETO custom claims onto Cedar `Forge::Principal` attributes via `[schema_forge.authz.principal_claims]` so hand-written custom Cedar policies can read per-bearer values like `principal.client_org_id`, including the IN-side `source = { user_field = "<f>" }` projection that populates those claims from User columns at login/refresh time.
+description: Use when writing, creating, editing, or reviewing SchemaForge .schema files. Use when defining data models, entity schemas, field types (incl. `duration`, `bytes`, and `map<text, V>`), relations, access control, or multi-tenant hierarchies in the SchemaForge DSL syntax. Use when declaring write-time validation, computed fields, or computed defaults via the CEL rule annotations `@require` / `@compute` / `@default` (in-process, fail-closed, no gRPC), including single-hop cross-entity reads (`related.<field>.<col>`) inside `@require`. Use when declaring `unique` field constraints (per-tenant for `@tenant(...)` schemas, table-wide otherwise) and handling the 409 `unique_violation` error path. Use when declaring `file` fields backed by S3-compatible storage (MinIO, AWS S3, R2, Wasabi), configuring `[schema_forge.storage]` backends, or wiring upload/download/scan flows. Use when scaffolding or regenerating the React site with `schema-forge site generate`, wiring the `/app/*` per-entity pages or the runtime-dynamic `/admin/*` shell, or iterating with the `--templates-dir` override loader. Use when querying entities via the REST API, filtering, sorting, pagination, or building query parameters. Use when declaring lifecycle hooks via @hook annotations (including `before_upload`, `after_upload`, `on_scan_complete` for file fields), scaffolding hook gRPC services with `schema-forge hooks generate`, configuring [schema_forge.hooks] bindings, or auditing hooks with `hooks list` / `hooks diff`. Use when hitting `/api/v1/forge/auth/login`, `/auth/refresh`, or `/api/v1/forge/users` for the PASETO bootstrap and user management flows. Use when mapping PASETO custom claims onto Cedar `Forge::Principal` attributes via `[schema_forge.authz.principal_claims]` so hand-written custom Cedar policies can read per-bearer values like `principal.client_org_id`, including the IN-side `source = { user_field = "<f>" }` projection that populates those claims from User columns at login/refresh time. Use whenever a SchemaForge task touches the platform layer underneath the schemas — auth, accounts, sessions, TLS, gRPC transport, rate limiting, resilience, audit, health probes, metrics, caching, or config — because SchemaForge runs on acton-service and most such work is a feature flag plus a config section rather than new code; this skill carries the boundary between what the framework owns and what SchemaForge owns.
 ---
 
 # SchemaForge — Schema Authoring & CLI Guide
@@ -32,8 +32,78 @@ SchemaForge is an Adaptive Object Model runtime with a human-readable DSL. One `
 | `schema-forge-acton` | 0.34.0 | Axum/acton-service integration: REST API, the write-time rule phases (`@default`→`@compute`→`@require`, incl. tenant-scoped cross-entity reads), Cedar policy store (hot-recompiled atomically on schema apply), auth, hook dispatcher, S3 storage registry (`aws-sdk-s3`), and the 409 `unique_violation` HTTP error envelope |
 | `schema-forge-cli` | 0.35.0 | CLI binary (`schemaforge`) built with clap derive; routes all configuration through `acton_service::Config<SchemaForgeConfig>` (single source of truth); ships `policies validate`, `bootstrap-admin`, `entity file upload`/`download` (presigned S3 handshake for `file` fields), and a site generator that surfaces `unique` as an inline form hint plus a 409-routed `setError` for CI / first-run provisioning |
 
+## Before You Build: acton-service Owns the Platform Layer
+
+SchemaForge is not a standalone server. It is an **application built on acton-service**, a
+production Rust service framework with ~57 feature flags that already ships most of what a
+government-grade backend needs: authentication, account lifecycle, sessions and CSRF, Cedar
+authorization, gRPC, TLS and mutual TLS, rate limiting, resilience, audit logging, health and
+readiness probes, metrics, pagination, and background workers.
+
+This matters because the most common failure when working in this repo is **building something
+acton-service already provides**. The symptom is always the same shape: a task looks like it needs
+a new subsystem, so a subsystem gets written — when the actual fix was enabling a feature flag and
+adding a config section. That mistake is expensive twice over: once to write the code, and again
+forever, because a hand-rolled subsystem does not receive the framework's security fixes.
+
+### The check, before writing any platform code
+
+When a task touches auth, sessions, tokens, accounts, authorization, rate limiting, TLS, gRPC
+transport, health probes, metrics, audit, caching, pagination, background jobs, or config —
+anything that is *infrastructure* rather than *schema semantics* — do this first:
+
+1. **Read the live feature inventory.** Run `cargo info acton-service --verbose`. Treat its output
+   as authoritative for the current version, the full feature list, and each feature's dependency
+   mapping. It queries the registry, so it cannot go stale the way this file can.
+2. **Consult the `acton-service-features` skill** for what those features *mean* and how they
+   combine (mutual exclusions, implied features, config sections).
+3. **Check what this workspace actually enables.** The pin and feature set live in
+   `crates/schema-forge-acton/Cargo.toml` and `crates/schema-forge-cli/Cargo.toml`. A capability
+   can be absent simply because its flag is off, not because the framework lacks it.
+4. **Only then decide.** If acton-service covers it, the change is a feature flag plus a config
+   section — not a module.
+
+### Where the line falls
+
+| acton-service owns | SchemaForge owns |
+|---|---|
+| Config loading and precedence (`Config<SchemaForgeConfig>`), XDG search, `ACTON_*` env layering | The `[schema_forge.*]` extension (`T`) and its validation |
+| PASETO/JWT generation and validation, refresh-token rotation, API keys, key rotation, OAuth/OIDC | Login/refresh route semantics specific to the entity model |
+| Account lifecycle (`accounts`), prebuilt `/accounts/*` routes, login lockout, notification hooks | User records *as schema entities*, `EntityAuthStore`, invite/onboard policy |
+| Sessions, CSRF, flash messages | — |
+| The Cedar *engine integration* (`cedar-authz`): decision caching, middleware, gRPC layer, `[cedar]` config | Cedar **policy generation** from schemas: per-entity schema emission, `role_rank`, tenant scoping, placeholder resources. This part is genuinely SchemaForge's and should stay. |
+| gRPC transport (`grpc`): tonic/prost, health, reflection, token auth + Cedar authz on RPCs | Hook *dispatch* semantics and the `@hook` annotation model |
+| TLS, mutual TLS, client-cert verification, credential rotation | — |
+| Rate limiting, resilience (circuit breaker, bulkhead), security headers, request IDs, CORS | — |
+| Audit (BLAKE3 hash chain, syslog/OTLP export, HTTP audit middleware) | Which domain events are worth auditing |
+| Health/readiness probes, app-defined checks, graceful shutdown, metrics (OTLP push and Prometheus scrape) | Schema-apply and migration readiness semantics |
+| Pagination primitives, repository/handlers patterns, background worker | Query IR, filter translation, per-backend SQL/SurrealQL codegen |
+
+The rule of thumb: **if it would be true of any service, it belongs to acton-service. If it is true
+only because schemas are the source of truth, it belongs to SchemaForge.**
+
+### Signs you are about to reinvent something
+
+- You are about to add a direct dependency that acton-service already re-exports or feature-gates
+  (`tonic`, `prost`, `rustls`, `cedar-policy`, `async-graphql`, `redis`, `tower-sessions`). Check
+  whether a feature flag brings it in already wired, with the framework's middleware attached.
+- You are writing a middleware layer for a cross-cutting concern.
+- You are writing a `TODO: remove once acton-service supports …`. Roland maintains acton-service
+  (`~/code/active/acton-service`). The correct move is usually to file it there, not to work around
+  it here — a workaround in this repo is permanent, and an upstream fix is not.
+- The task description contains "we need our own X" where X is a platform noun.
+
+### Keep the pin in view
+
+This workspace pins a specific acton-service version. Because SchemaForge inherits the framework's
+**security posture**, a stale pin is not merely missing features — it is missing fixes. When the pin
+lags the registry by more than a minor version or two, say so rather than working around the older
+behavior, and check the upstream `CHANGELOG.md` for security entries that apply to the features this
+workspace enables.
+
 ## When to Use
 
+- **Any task touching the platform layer** (auth, accounts, sessions, TLS, gRPC transport, rate limiting, resilience, audit, health probes, metrics, caching, config) — start at "Before You Build" above and check acton-service before writing code
 - Writing new `.schema` files for SchemaForge projects
 - Adding entities, fields, relations, or annotations to existing schemas
 - Reviewing or validating DSL syntax
@@ -789,6 +859,12 @@ From a `.schema` file, SchemaForge produces:
 
 For complete details, load these supporting files:
 
+- For **anything on the platform layer** — auth, accounts, sessions, TLS/mTLS, gRPC transport, rate
+  limiting, resilience, audit, health checks, metrics, caching, pagination, background workers — use
+  the **`acton-service-features` skill**, and run `cargo info acton-service --verbose` for the
+  authoritative current feature list. See "Before You Build" above for why this comes first. The
+  framework source is at `~/code/active/acton-service`; its `CHANGELOG.md` is the reference for
+  which security fixes a given pin does or does not include.
 - For **complete syntax reference** including EBNF grammar, all annotation parameters, and constraint details, see [dsl-reference.md](dsl-reference.md)
 - For **annotated real-world examples** covering CRM, multi-tenant, project management, and HR domains, see [examples.md](examples.md)
 - For **design patterns** including multi-tenancy, access control, dashboards, composites, relations, and widget selection, see [patterns.md](patterns.md)


### PR DESCRIPTION
Promotes two changes from `dev`.

## #123 — `chore(deps)`: acton-service 0.27.0 → 0.34.1

The pin was 7 minor versions and 64 commits behind. Because SchemaForge inherits acton-service's security posture, that meant missing **fixes**, not just features. Four apply to features this workspace already enables:

- **Audit chain hash omitted half the event** (0.31.2) — `metadata`, source IP, user agent, request ID and duration were excluded, so a tampered role list or forged origin verified as intact. Given the government-audit posture this is the one that mattered most.
- **Audit source IP trusted `X-Forwarded-For`** (0.31.2) — falsifiable recorded origin.
- **`/admin/config/drift` mounted unconditionally** (0.31.2) — token-gated here via the global PASETO layer, but no role gate.
- **Invalid PASETO config skipped the auth middleware entirely** (0.29.0) — a typo in `[paseto]` was a silent, total auth bypass.

Both new keys default fail-safe, so the bump closes all four with no config change. **Zero source changes** — all seven breaking changes on the path turned out to be no-ops here.

## #122 — `docs(skill)`: acton-service gate in the schemaforge skill

Adds a *Before You Build* section so platform-layer work checks acton-service before writing code. Docs only.

## Verification on merged `dev`

- `cargo nextest run --workspace --features surrealdb` — **2164 passed**, 4 skipped
- `cargo check --all-targets` clean on both surrealdb and postgres paths
- `cargo clippy --all-targets` clean

## Not a release

No version bumps. `release.yml` is tag-triggered, so this merge publishes nothing. The acton-service bump is worth a version bump whenever the next release is actually cut.