### PR TITLE
chore(deps)!: upgrade acton-service 0.34.1 -> 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "acton-macro"
-version = "8.1.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e38f7952c657ecc04cffdce225eb5771b9d03588372bcc3067e2a8605a763f"
+checksum = "2dd183bb8d4ad7ff80ff1340c05b3cb646421b0d67e443613127aaf334900c4e"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "acton-reactive"
-version = "8.1.1"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a6ba0a28db7345767ff2a3c0246a69ea8098e56052581e78bcee8858f6a410"
+checksum = "4d77895b052a39ba98f84425c3169686f05027a0c86901e34527a9c986b374d9"
 dependencies = [
  "acton-ern",
  "acton-macro",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "acton-service"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f16b067374834c7c2879acc85ff4977b71fa19f5980ff09a9fb9d1c890d0a2"
+checksum = "56e2d75ff51006c410a33c199e33bf78dcc789e6008ac05b5a2994e6a1cee97a"
 dependencies = [
  "acton-reactive",
  "anyhow",
@@ -3950,7 +3950,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4481,7 +4481,7 @@ dependencies = [
  "percent-encoding",
  "quoted_printable",
  "rustls 0.23.40",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio",
  "tokio-rustls 0.26.4",
  "url",
@@ -4904,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -6220,7 +6220,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6258,7 +6258,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8122,12 +8122,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8969,6 +8969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9250,9 +9261,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -9260,20 +9271,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9493,7 +9504,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",

--- a/crates/schema-forge-acton/Cargo.toml
+++ b/crates/schema-forge-acton/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["sync"] }
-acton-service = { version = "0.34.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.35.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 schema-forge-dsl = { path = "../schema-forge-dsl" }
 schema-forge-surrealdb = { path = "../schema-forge-surrealdb", optional = true }
 schema-forge-postgres = { path = "../schema-forge-postgres", optional = true }

--- a/crates/schema-forge-acton/src/actor.rs
+++ b/crates/schema-forge-acton/src/actor.rs
@@ -98,6 +98,30 @@ impl ActorExtension for ForgeActor {
         configure_registry_mutations(actor);
         configure_backend_operations(actor);
     }
+
+    /// Do not restart this actor.
+    ///
+    /// `configure` registers handlers but sets no state: the registry,
+    /// backend, tenant config, policy store, storage registry and hook
+    /// dispatcher all arrive in the single [`InitForge`] message `serve`
+    /// sends at boot. A restart rebuilds from `configure`, so the
+    /// replacement would come back with `Default` state — an empty registry
+    /// and no backend — and nothing would ever send it a second `InitForge`.
+    ///
+    /// The result would be a process that stays up and answers `404 schema
+    /// not found` on every entity route. That is fail-closed, but it points
+    /// an operator at a data problem when the actual fault is an actor that
+    /// died. Refusing the restart keeps the failure legible: the handle
+    /// resolves to `None` and routes answer `500` naming the missing actor.
+    ///
+    /// This also preserves the behaviour of acton-service <= 0.34.1, where
+    /// the declared policy was never read and no extension could restart at
+    /// all. Making `ForgeActor` genuinely restartable means giving it a way
+    /// to re-initialise itself from the backend; until then, `Permanent`
+    /// would be a promise the actor cannot keep.
+    fn restart_policy() -> RestartPolicy {
+        RestartPolicy::Temporary
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -543,4 +567,47 @@ fn configure_backend_operations(actor: &mut ManagedActor<Idle, ForgeActor>) {
             reply.send(result).await;
         })
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the reasoning behind [`ForgeActor::restart_policy`].
+    ///
+    /// acton-service 0.35.0 made the declared restart policy effective for
+    /// the first time, so this stopped being a dormant declaration and became
+    /// live supervision behaviour. `Temporary` is only the right answer for
+    /// as long as a rebuilt-from-`Default` `ForgeActor` is unusable — the
+    /// assertions below are that condition, not the policy value. If someone
+    /// later teaches the actor to re-initialise itself from the backend, this
+    /// test fails and the policy should be revisited rather than the test
+    /// relaxed.
+    #[test]
+    fn a_restarted_forge_actor_would_be_unusable() {
+        let rebuilt = ForgeActor::default();
+        assert!(
+            rebuilt.backend.is_none(),
+            "a restart rebuilds from Default, so the backend would be lost"
+        );
+        assert!(
+            rebuilt.registry.is_empty(),
+            "a restart rebuilds from Default, so every schema would be lost"
+        );
+        assert!(
+            rebuilt.policy_store.is_none(),
+            "a restart rebuilds from Default, so authz would have no store"
+        );
+        assert_eq!(ForgeActor::restart_policy(), RestartPolicy::Temporary);
+    }
+
+    /// The contrasting case: `HookDispatchActor` carries no state, so the
+    /// default `Permanent` policy is genuinely correct for it.
+    #[test]
+    fn hook_dispatch_actor_is_restartable() {
+        assert_eq!(
+            crate::hooks::HookDispatchActor::restart_policy(),
+            RestartPolicy::Permanent
+        );
+    }
 }

--- a/crates/schema-forge-acton/src/hooks/dispatch_actor.rs
+++ b/crates/schema-forge-acton/src/hooks/dispatch_actor.rs
@@ -41,6 +41,12 @@ use super::{run_after_hook, HookDispatcher, HookInvocation, HooksConfig};
 #[derive(Default, Debug)]
 pub struct HookDispatchActor;
 
+// Restart policy is left at the default (`Permanent`), which acton-service
+// 0.35.0 made effective for the first time. That is the right policy here
+// precisely because this actor is stateless: every input travels with the
+// message, so a rebuilt-from-`Default` replacement is indistinguishable from
+// the original. Contrast `ForgeActor`, whose whole state arrives in one
+// `InitForge` at boot and which therefore opts out.
 impl ActorExtension for HookDispatchActor {
     fn configure(actor: &mut ManagedActor<Idle, Self>) {
         actor.act_on::<DispatchHook>(|_actor, ctx| {

--- a/crates/schema-forge-acton/src/routes/entities.rs
+++ b/crates/schema-forge-acton/src/routes/entities.rs
@@ -1177,7 +1177,7 @@ async fn execute_entity_query(
     // relation-display machinery treats derived fields identically to
     // stored RefArrays.
     populate_derived_collections(
-        forge,
+        &forge,
         schema_def,
         &mut visible_entities,
         claims,
@@ -1190,7 +1190,7 @@ async fn execute_entity_query(
     // relation field is still scrubbed from the envelope alongside its
     // `__display` sibling below.
     let display_map = if resolve_relations && !visible_entities.is_empty() {
-        resolve_relation_displays(forge, schema_def, &visible_entities, claims, &tenant_config)
+        resolve_relation_displays(&forge, schema_def, &visible_entities, claims, &tenant_config)
             .await?
     } else {
         HashMap::new()
@@ -2019,7 +2019,7 @@ pub async fn create_entity(
     // `related.<F>.<col>` is dereferenced to its tenant-scoped related row and
     // injected as a CEL binding before the pure evaluator runs.
     check_requires_with_related(
-        forge,
+        &forge,
         &schema_def,
         &fields,
         claims.as_ref(),
@@ -2035,7 +2035,7 @@ pub async fn create_entity(
     // (possibly mutated) fields.
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     let hook_dispatcher = if hooks_config.enabled && schema_def.has_hooks() {
-        fetch_hook_dispatcher(forge).await
+        fetch_hook_dispatcher(&forge).await
     } else {
         None
     };
@@ -2183,7 +2183,7 @@ pub async fn list_entities(
     // before_read hook gate (no entity_id, no fields — list scope).
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     if hooks_config.enabled && schema_def.hook_for(HookEvent::BeforeRead).is_some() {
-        if let Some(dispatcher) = fetch_hook_dispatcher(forge).await {
+        if let Some(dispatcher) = fetch_hook_dispatcher(&forge).await {
             let mut empty = BTreeMap::new();
             apply_read_hook(
                 BeforeHookCtx {
@@ -2328,7 +2328,7 @@ pub async fn query_entities(
     // before_read hook gate (no entity_id, no fields — query scope).
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     if hooks_config.enabled && schema_def.hook_for(HookEvent::BeforeRead).is_some() {
-        if let Some(dispatcher) = fetch_hook_dispatcher(forge).await {
+        if let Some(dispatcher) = fetch_hook_dispatcher(&forge).await {
             let mut empty = BTreeMap::new();
             apply_read_hook(
                 BeforeHookCtx {
@@ -2475,7 +2475,7 @@ pub async fn get_entity(
         && (schema_def.hook_for(HookEvent::BeforeRead).is_some()
             || schema_def.hook_for(HookEvent::AfterRead).is_some())
     {
-        fetch_hook_dispatcher(forge).await
+        fetch_hook_dispatcher(&forge).await
     } else {
         None
     };
@@ -2577,7 +2577,7 @@ pub async fn get_entity(
     // helper handles one or many entities the same way.
     let mut single = [entity];
     populate_derived_collections(
-        forge,
+        &forge,
         &schema_def,
         &mut single,
         claims.as_ref(),
@@ -2596,7 +2596,7 @@ pub async fn get_entity(
     if parse_truthy_flag(&params, "resolve") {
         let entities_slice = std::slice::from_ref(&entity);
         let display_map = resolve_relation_displays(
-            forge,
+            &forge,
             &schema_def,
             entities_slice,
             claims.as_ref(),
@@ -2738,7 +2738,7 @@ pub async fn update_entity(
     // CEL @require validation rules (#92) — fail-closed, in-transaction,
     // pre-persistence. Cross-entity reads (#95) resolved before evaluation.
     check_requires_with_related(
-        forge,
+        &forge,
         &schema_def,
         &fields,
         claims.as_ref(),
@@ -2753,7 +2753,7 @@ pub async fn update_entity(
     // validation, then `before_change` runs on the (possibly mutated) fields.
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     let hook_dispatcher = if hooks_config.enabled && schema_def.has_hooks() {
-        fetch_hook_dispatcher(forge).await
+        fetch_hook_dispatcher(&forge).await
     } else {
         None
     };
@@ -3015,7 +3015,7 @@ pub async fn patch_entity(
     // predicates that reference unpatched fields still see their current
     // values. Cross-entity reads (#95) resolved before evaluation.
     check_requires_with_related(
-        forge,
+        &forge,
         &schema_def,
         &merged,
         claims.as_ref(),
@@ -3029,7 +3029,7 @@ pub async fn patch_entity(
     // finalized post-patch state.
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     let hook_dispatcher = if hooks_config.enabled && schema_def.has_hooks() {
-        fetch_hook_dispatcher(forge).await
+        fetch_hook_dispatcher(&forge).await
     } else {
         None
     };
@@ -3251,7 +3251,7 @@ pub async fn delete_entity(
     // hook is configured so the dispatcher sees the fields being deleted.
     let hooks_config = state.config().custom.schema_forge.hooks.clone();
     let hook_dispatcher = if hooks_config.enabled && schema_def.has_hooks() {
-        fetch_hook_dispatcher(forge).await
+        fetch_hook_dispatcher(&forge).await
     } else {
         None
     };

--- a/crates/schema-forge-acton/src/routes/schemas.rs
+++ b/crates/schema-forge-acton/src/routes/schemas.rs
@@ -533,14 +533,14 @@ pub async fn create_schema(
     // 4a. Run the inverse-relation pairing pass across the full registry so
     // any `-> X[]` field paired with an FK from an existing schema is marked
     // as derived before the migration plan is generated.
-    pair_with_registry(forge, &mut definition).await?;
+    pair_with_registry(&forge, &mut definition).await?;
 
     // 4b. Pre-validate the proposed Cedar bundle BEFORE running any DB
     // migration. The actor will recompile and atomically swap on InsertSchema
     // anyway, but doing the dry-run here means a malformed schema is rejected
     // with a 400 instead of leaving the database in a state the running
     // policy bundle can't reason about.
-    precheck_policy_bundle(&state, forge, &definition, false).await?;
+    precheck_policy_bundle(&state, &forge, &definition, false).await?;
 
     // 5. Generate migration plan
     let plan = DiffEngine::create_new(&definition);
@@ -770,11 +770,11 @@ pub async fn update_schema(
     // 4a. Run the inverse-relation pairing pass before diffing, so newly
     // added `-> X[]` fields are classified as derived (and therefore
     // produce no AddRelation step for a physical column).
-    pair_with_registry(forge, &mut new_definition).await?;
+    pair_with_registry(&forge, &mut new_definition).await?;
 
     // 4b. Dry-run the Cedar bundle for the proposed registry state so an
     // invalid schema fails fast — before any DB migration.
-    precheck_policy_bundle(&state, forge, &new_definition, false).await?;
+    precheck_policy_bundle(&state, &forge, &new_definition, false).await?;
 
     // 5. Compute diff and generate migration plan
     let plan = DiffEngine::diff(&old_schema, &new_definition);

--- a/crates/schema-forge-backend/Cargo.toml
+++ b/crates/schema-forge-backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.13.0"
 edition = "2021"
 
 [dependencies]
-acton-service = { version = "0.34.1", default-features = false, features = ["crypto-aws-lc-rs"] }
+acton-service = { version = "0.35.0", default-features = false, features = ["crypto-aws-lc-rs"] }
 argon2 = { version = "0.5", features = ["std"] }
 async-trait = "0.1.89"
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -27,7 +27,7 @@ console = "0.15"
 dialoguer = "0.11"
 glob = "0.3"
 axum = { version = "0.8" }
-acton-service = { version = "0.34.1", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
+acton-service = { version = "0.35.0", default-features = false, features = ["http", "observability", "otel-metrics", "journald", "governor", "resilience", "audit", "openapi", "auth", "crypto-aws-lc-rs"] }
 heck = "0.5.0"
 minijinja = "2.19.0"
 tracing = "0.1.44"


### PR DESCRIPTION
Branched from `dev`, so this is independent of #125 (hook transport security). Whichever lands second will need a trivial rebase — they touch different files apart from `Cargo.lock`.

## What reaches us

0.35.0 bumps acton-reactive 8.1.1 → 9.0.0. Two things affect this workspace.

**`AppState::actor` returns an owned `Option<ActorHandle>`**, not a borrow — because a restart replaces the actor and a stored handle would silently go stale. Every route handler already resolved the handle per request, which is exactly the pattern that change is designed for, so this is mechanical: 18 call sites in `routes/entities.rs` and `routes/schemas.rs` now pass `&forge` to the helpers that borrow it.

**`ActorExtension::restart_policy` is now actually read.** This is the part worth reviewing. Before 0.35.0 the spawner used the legacy `supervise()`, which never consulted the policy and registered children with no blueprint, so no extension could be restarted at all — the declared policy was inert. The default `Permanent` is now live for the first time, and the two extensions here want opposite answers.

## `HookDispatchActor` → stays `Permanent`

`struct HookDispatchActor;` carries no state; every input travels with the `DispatchHook` message. A replacement rebuilt from `Default` is indistinguishable from the original. This is a genuine gain — post-commit hook dispatch now survives a handler panic.

## `ForgeActor` → opts out with `Temporary`

`configure` registers handlers but sets no state. The registry, backend, tenant config, policy store, storage registry and hook dispatcher all arrive in the single `InitForge` that `serve` sends at boot, and nothing would ever send a second one.

So a restarted `ForgeActor` would come back with an empty registry and no backend: a process that stays up and answers `404 schema not found` on every entity route. That is fail-closed — the empty `policy_store` denies everything — but it points an operator at a data problem when the actual fault is a dead actor. Declining the restart keeps the failure legible (the handle resolves to `None`, routes answer `500` naming the missing actor) and preserves 0.34.1 behaviour, where no restart was possible.

Making `ForgeActor` genuinely restartable means giving it a way to re-initialise from the backend. That is its own change, not a side effect of a version bump — happy to file it if you want it.

## Test choice

`a_restarted_forge_actor_would_be_unusable` asserts the *condition* behind the policy (no backend, empty registry, no policy store after `Default`), not just the policy value. The acton-service commit itself notes the old policy was "declared, documented, unit-tested for its return value, and consumed by nothing" — a return-value test is the weak version. This one fails if someone later teaches the actor to self-initialise, which is the moment the policy should be revisited.

## Verification

2166 tests pass (+2), clippy clean workspace-wide with `--features surrealdb`.