### PR TITLE
Publish signed Windows MSSQL releases

### DIFF
--- a/.github/workflows/mssql-integration.yml
+++ b/.github/workflows/mssql-integration.yml
@@ -1,0 +1,47 @@
+name: MSSQL Integration
+
+on:
+  pull_request:
+    paths:
+      - "crates/schema-forge-mssql/**"
+      - "crates/schema-forge-cli/Cargo.toml"
+      - "crates/schema-forge-acton/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/mssql-integration.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sql-server:
+    name: SQL Server ${{ matrix.version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: 2019
+            test: connects_and_initializes_metadata_on_sql_server_2019
+          - version: 2022
+            test: connects_and_initializes_metadata_on_sql_server_2022
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system build dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libkrb5-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run SQL Server integration test
+        env:
+          TEST_NAME: ${{ matrix.test }}
+        run: >-
+          cargo test --package schema-forge-mssql --test sql_server
+          "$TEST_NAME" -- --ignored --exact --nocapture

--- a/.github/workflows/mssql-integration.yml
+++ b/.github/workflows/mssql-integration.yml
@@ -14,6 +14,29 @@ permissions:
   contents: read
 
 jobs:
+  windows-build:
+    name: Windows MSSQL build
+    runs-on: windows-2025
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Protocol Buffers compiler
+        shell: pwsh
+        run: choco install protoc --no-progress --yes
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build native Windows MSSQL binary
+        run: >-
+          cargo build --package schema-forge-cli --bin schemaforge
+          --no-default-features --features mssql
+
   sql-server:
     name: SQL Server ${{ matrix.version }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
 
     strategy:
       matrix:
@@ -25,22 +28,32 @@ jobs:
             suffix: surrealdb
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            archive: tar.gz
           - backend: postgres
             suffix: postgres
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            archive: tar.gz
           - backend: mssql
             suffix: mssql
             runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          - backend: mssql
+            suffix: mssql
+            runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            archive: zip
           - backend: surrealdb
             suffix: surrealdb
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            archive: tar.gz
           - backend: postgres
             suffix: postgres
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            archive: tar.gz
 
     env:
       TAG_NAME: ${{ github.ref_name }}
@@ -51,8 +64,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install system build dependencies
+      - name: Install Linux system build dependencies
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libkrb5-dev
+
+      - name: Install Windows system build dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install protoc --no-progress --yes
 
       - name: Verify Rust toolchain
         run: rustc --version && cargo --version
@@ -61,6 +80,7 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Download + verify the signed console bundle
+        shell: bash
         env:
           # GITHUB_TOKEN can read another OSS repo's releases in the same org.
           # If schemaforge-console is private, swap for a scoped PAT/app token.
@@ -94,7 +114,23 @@ jobs:
           SCHEMAFORGE_CONSOLE_DIST: ${{ github.workspace }}/console-dist
         run: cargo build --release --package schema-forge-cli --no-default-features --features ${{ matrix.backend }},embedded-console
 
-      - name: Package
+      - name: Sign and verify Windows binary (Sigstore keyless)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign-blob `
+            --bundle target/release/schemaforge.exe.sigstore.json `
+            target/release/schemaforge.exe
+          cosign verify-blob `
+            --bundle target/release/schemaforge.exe.sigstore.json `
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com `
+            --certificate-identity-regexp '^https://github\.com/Govcraft/schemaforge/\.github/workflows/release\.yml@refs/tags/' `
+            target/release/schemaforge.exe
+
+      - name: Package Unix binary
+        if: runner.os != 'Windows'
         env:
           TARGET: ${{ matrix.target }}
           SUFFIX: ${{ matrix.suffix }}
@@ -103,11 +139,22 @@ jobs:
           tar czf "../../schemaforge-${TAG_NAME}-${TARGET}-${SUFFIX}.tar.gz" schemaforge
           cd ../..
 
+      - name: Package Windows binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          Compress-Archive `
+            -Path target/release/schemaforge.exe,target/release/schemaforge.exe.sigstore.json `
+            -DestinationPath "schemaforge-$env:TAG_NAME-$env:TARGET-$env:SUFFIX.zip"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: schemaforge-${{ matrix.target }}-${{ matrix.suffix }}
-          path: schemaforge-${{ github.ref_name }}-${{ matrix.target }}-${{ matrix.suffix }}.tar.gz
+          path: schemaforge-${{ github.ref_name }}-${{ matrix.target }}-${{ matrix.suffix }}.${{ matrix.archive }}
 
   release:
     needs: build
@@ -121,7 +168,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate SHA256SUMS
-        run: sha256sum schemaforge-*.tar.gz > SHA256SUMS
+        run: sha256sum schemaforge-*.tar.gz schemaforge-*.zip > SHA256SUMS
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -141,6 +188,7 @@ jobs:
           generate_release_notes: true
           files: |
             schemaforge-*.tar.gz
+            schemaforge-*.zip
             SHA256SUMS
             SHA256SUMS.sig
             SHA256SUMS.pem

--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ TAG=$(curl -fsSL https://api.github.com/repos/Govcraft/schemaforge/releases/late
   | sudo tar -xz -C /usr/local/bin
 ```
 
+For Windows with Microsoft SQL Server support, download
+`schemaforge-<version>-x86_64-pc-windows-msvc-mssql.zip`. The archive contains
+`schemaforge.exe` and its keyless Sigstore bundle,
+`schemaforge.exe.sigstore.json`.
+
 Each command downloads the latest release tarball, extracts the `schemaforge` binary into `/usr/local/bin`, and leaves it immediately runnable. To install somewhere on your `PATH` without `sudo`, swap `/usr/local/bin` for a user-writable directory such as `~/.local/bin`.
 
 The backend is compiled in — there is no runtime flag to switch among PostgreSQL,
@@ -158,6 +163,20 @@ cosign verify-blob \
 ```
 
 A successful run prints `Verified OK`. The `cosign` binary is available from [sigstore/cosign](https://github.com/sigstore/cosign/releases) (single static binary, no daemon).
+
+The Windows executable is also signed directly. After extracting its ZIP,
+verify it from PowerShell before execution:
+
+```powershell
+cosign verify-blob `
+  --bundle schemaforge.exe.sigstore.json `
+  --certificate-identity-regexp '^https://github\.com/Govcraft/schemaforge/\.github/workflows/release\.yml@refs/tags/' `
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com `
+  schemaforge.exe
+```
+
+This is a Sigstore signature tied to the tagged GitHub Actions workflow, not an
+Authenticode publisher certificate.
 
 ### Build from Source (alternative)
 

--- a/crates/schema-forge-mssql/tests/sql_server.rs
+++ b/crates/schema-forge-mssql/tests/sql_server.rs
@@ -9,7 +9,7 @@ use schema_forge_core::types::{
 };
 use schema_forge_mssql::MssqlBackend;
 use testcontainers::core::{IntoContainerPort, WaitFor};
-use testcontainers::runners::SyncRunner;
+use testcontainers::runners::AsyncRunner;
 use testcontainers::{GenericImage, ImageExt};
 
 const SA_PASSWORD: &str = "SchemaForge_test_2026!";
@@ -35,9 +35,11 @@ async fn connects_and_initializes_metadata(image_tag: &str) {
         .with_env_var("ACCEPT_EULA", "Y")
         .with_env_var("MSSQL_SA_PASSWORD", SA_PASSWORD)
         .start()
+        .await
         .expect("start SQL Server container");
     let port = container
         .get_host_port_ipv4(1433.tcp())
+        .await
         .expect("mapped SQL Server port");
     let config = toml::from_str(&format!(
         "url = 'Server=127.0.0.1,{port};User Id=sa;Password={SA_PASSWORD};\

--- a/crates/schema-forge-mssql/tests/sql_server.rs
+++ b/crates/schema-forge-mssql/tests/sql_server.rs
@@ -1,4 +1,12 @@
-use schema_forge_backend::SchemaBackend;
+use std::collections::BTreeMap;
+
+use schema_forge_backend::{Entity, EntityStore, SchemaBackend};
+use schema_forge_core::migration::{DiffEngine, MigrationStep};
+use schema_forge_core::query::{AggregateOp, AggregateQuery, FieldPath, Filter, Query, SortOrder};
+use schema_forge_core::types::{
+    DynamicValue, FieldDefinition, FieldName, FieldType, IntegerConstraints, SchemaDefinition,
+    SchemaId, SchemaName, TextConstraints,
+};
 use schema_forge_mssql::MssqlBackend;
 use testcontainers::core::{IntoContainerPort, WaitFor};
 use testcontainers::runners::SyncRunner;
@@ -8,8 +16,18 @@ const SA_PASSWORD: &str = "SchemaForge_test_2026!";
 
 #[tokio::test]
 #[ignore = "requires Docker and acceptance of the SQL Server container EULA"]
-async fn connects_and_initializes_metadata_with_testcontainers() {
-    let container = GenericImage::new("mcr.microsoft.com/mssql/server", "2022-latest")
+async fn connects_and_initializes_metadata_on_sql_server_2019() {
+    connects_and_initializes_metadata("2019-latest").await;
+}
+
+#[tokio::test]
+#[ignore = "requires Docker and acceptance of the SQL Server container EULA"]
+async fn connects_and_initializes_metadata_on_sql_server_2022() {
+    connects_and_initializes_metadata("2022-latest").await;
+}
+
+async fn connects_and_initializes_metadata(image_tag: &str) {
+    let container = GenericImage::new("mcr.microsoft.com/mssql/server", image_tag)
         .with_exposed_port(1433.tcp())
         .with_wait_for(WaitFor::message_on_stdout(
             "SQL Server is now ready for client connections",
@@ -35,4 +53,156 @@ async fn connects_and_initializes_metadata_with_testcontainers() {
         .await
         .expect("list initialized metadata")
         .is_empty());
+
+    exercises_backend_contract(&backend).await;
+}
+
+async fn exercises_backend_contract(backend: &MssqlBackend) {
+    let schema = product_schema();
+    let plan = DiffEngine::create_new(&schema);
+    backend
+        .apply_migration(&schema.name, &plan.steps)
+        .await
+        .expect("create product table");
+    backend
+        .store_schema_metadata(&schema)
+        .await
+        .expect("store product schema metadata");
+    assert_eq!(
+        backend
+            .load_schema_metadata(&schema.name)
+            .await
+            .expect("load product schema metadata"),
+        Some(schema.clone())
+    );
+
+    let alpha = product(&schema.name, "Alpha", 10, true);
+    let mut bravo = product(&schema.name, "Bravo", 20, true);
+    let charlie = product(&schema.name, "Charlie", 30, false);
+    for entity in [&alpha, &bravo, &charlie] {
+        assert_eq!(
+            backend.create(entity).await.expect("create product"),
+            *entity
+        );
+    }
+    assert_eq!(
+        backend
+            .get(&schema.name, &alpha.id)
+            .await
+            .expect("get product"),
+        alpha
+    );
+
+    bravo
+        .fields
+        .insert("price".into(), DynamicValue::Integer(25));
+    backend.update(&bravo).await.expect("update product");
+    assert_eq!(
+        backend
+            .get(&schema.name, &bravo.id)
+            .await
+            .expect("get updated product")
+            .field("price"),
+        Some(&DynamicValue::Integer(25))
+    );
+
+    let active_filter = Filter::eq(FieldPath::single("active"), DynamicValue::Boolean(true));
+    let page = backend
+        .query(
+            &Query::new(schema.id.clone())
+                .with_filter(active_filter.clone())
+                .with_sort(FieldPath::single("price"), SortOrder::Descending)
+                .with_limit(1)
+                .with_offset(1)
+                .with_projection(vec!["name".into()]),
+        )
+        .await
+        .expect("query products");
+    assert_eq!(page.total_count, Some(2));
+    assert_eq!(page.entities.len(), 1);
+    assert_eq!(
+        page.entities[0].field("name"),
+        Some(&DynamicValue::Text("Alpha".into()))
+    );
+    assert_eq!(page.entities[0].field_count(), 1);
+    assert_eq!(
+        backend
+            .count(&Query::new(schema.id.clone()).with_filter(active_filter.clone()))
+            .await
+            .expect("count active products"),
+        2
+    );
+
+    let aggregates = backend
+        .aggregate(
+            &AggregateQuery::new(schema.id.clone())
+                .with_filter(active_filter)
+                .with_ops(vec![
+                    AggregateOp::Count,
+                    AggregateOp::Sum {
+                        field: FieldPath::single("price"),
+                    },
+                    AggregateOp::Avg {
+                        field: FieldPath::single("price"),
+                    },
+                ]),
+        )
+        .await
+        .expect("aggregate active products");
+    assert_eq!(
+        aggregates
+            .iter()
+            .map(|result| result.value)
+            .collect::<Vec<_>>(),
+        vec![2.0, 35.0, 17.5]
+    );
+
+    backend
+        .delete(&schema.name, &charlie.id)
+        .await
+        .expect("delete product");
+    assert!(backend.get(&schema.name, &charlie.id).await.is_err());
+    backend
+        .apply_migration(
+            &schema.name,
+            &[MigrationStep::DropSchema {
+                name: schema.name.clone(),
+            }],
+        )
+        .await
+        .expect("drop product table");
+}
+
+fn product_schema() -> SchemaDefinition {
+    SchemaDefinition::new(
+        SchemaId::new(),
+        SchemaName::new("Product").expect("valid schema name"),
+        vec![
+            FieldDefinition::new(
+                FieldName::new("name").expect("valid field name"),
+                FieldType::Text(TextConstraints::unconstrained()),
+            ),
+            FieldDefinition::new(
+                FieldName::new("price").expect("valid field name"),
+                FieldType::Integer(IntegerConstraints::unconstrained()),
+            ),
+            FieldDefinition::new(
+                FieldName::new("active").expect("valid field name"),
+                FieldType::Boolean,
+            ),
+        ],
+        vec![],
+    )
+    .expect("valid product schema")
+}
+
+fn product(schema: &SchemaName, name: &str, price: i64, active: bool) -> Entity {
+    Entity::new(
+        schema.clone(),
+        BTreeMap::from([
+            ("name".into(), DynamicValue::Text(name.into())),
+            ("price".into(), DynamicValue::Integer(price)),
+            ("active".into(), DynamicValue::Boolean(active)),
+        ]),
+    )
 }


### PR DESCRIPTION
## Summary

- publish an x86_64 Windows/MSVC MSSQL ZIP from the release workflow
- keylessly sign and verify `schemaforge.exe` with Sigstore before packaging
- run the Testcontainers MSSQL backend contract against SQL Server 2019 and 2022
- document Windows download and executable signature verification

## Validation

- `cargo test --package schema-forge-mssql --test sql_server --no-run`
- `cargo clippy --package schema-forge-mssql --test sql_server -- -D warnings`
- `actionlint .github/workflows/*.yml`

The live container matrix runs in CI because the local host exposes Podman rather than a Docker daemon.