### PR TITLE
Release SchemaForge v0.37.2

### DIFF
--- a/.github/workflows/mssql-integration.yml
+++ b/.github/workflows/mssql-integration.yml
@@ -32,6 +32,28 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Verify console signature with Windows Git Bash
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MSYS_NO_PATHCONV: "1"
+        run: |
+          set -euo pipefail
+          gh release download v0.1.0 \
+            --repo Govcraft/schemaforge-console \
+            --pattern 'SHA256SUMS' \
+            --pattern 'SHA256SUMS.sig' \
+            --pattern 'SHA256SUMS.pem'
+          cosign verify-blob \
+            --certificate SHA256SUMS.pem \
+            --signature SHA256SUMS.sig \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github\.com/Govcraft/schemaforge-console/\.github/workflows/release\.yml@' \
+            SHA256SUMS
+
       - name: Build native Windows MSSQL binary
         run: >-
           cargo build --package schema-forge-cli --bin schemaforge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
           # GITHUB_TOKEN can read another OSS repo's releases in the same org.
           # If schemaforge-console is private, swap for a scoped PAT/app token.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prevent Git Bash/MSYS from rewriting URL-shaped cosign regex args
+          # into Windows paths before they reach the native executable.
+          MSYS_NO_PATHCONV: "1"
         run: |
           set -euo pipefail
           gh release download "$CONSOLE_VERSION" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8187,7 +8187,7 @@ dependencies = [
 
 [[package]]
 name = "schema-forge-cli"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "acton-service",
  "assert_cmd",

--- a/crates/schema-forge-cli/Cargo.toml
+++ b/crates/schema-forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema-forge-cli"
-version = "0.37.1"
+version = "0.37.2"
 edition = "2021"
 
 [[bin]]

--- a/skills/schemaforge/SKILL.md
+++ b/skills/schemaforge/SKILL.md
@@ -9,7 +9,7 @@ description: Use when writing, creating, editing, or reviewing SchemaForge .sche
 
 SchemaForge is an Adaptive Object Model runtime with a human-readable DSL. One `.schema` file produces database tables, REST API endpoints, migrations, Cedar authorization policies, and OpenAPI specs — no recompilation required.
 
-**Version:** 0.37.1
+**Version:** 0.37.2
 
 **Core principle:** Schemas are the single source of truth for the entire entity lifecycle. Authorization is **Cedar-canonical**: every read/write/delete decision flows through the embedded Cedar engine — there are no parallel custom guards.
 
@@ -33,7 +33,7 @@ integrated SSPI/Kerberos authentication.
 | `schema-forge-postgres` | 0.8.0 | PostgreSQL backend implementation (via sqlx), incl. JSONB-backed file/map columns, `BIGINT`-nanosecond durations, `BYTEA` bytes with octet-length CHECK, and SQLSTATE 23505 → typed `UniqueViolation` mapping |
 | `schema-forge-mssql` | 0.1.0 | Microsoft SQL Server backend via Tiberius and acton-service pools, including integrated SSPI/Kerberos authentication, JSON document storage, CRUD, filtering, sorting, pagination, and aggregates |
 | `schema-forge-acton` | 0.36.0 | Axum/acton-service integration: REST API, unified bearer/mTLS/Windows claims, the write-time rule phases (`@default`→`@compute`→`@require`, incl. tenant-scoped cross-entity reads), Cedar policy store, auth, hook dispatch, S3 storage, and typed HTTP errors |
-| `schema-forge-cli` | 0.37.1 | CLI binary (`schemaforge`) with SurrealDB, PostgreSQL, and SQL Server release flavors; routes configuration through `acton_service::Config<SchemaForgeConfig>` and supports trusted-proxy Windows authentication |
+| `schema-forge-cli` | 0.37.2 | CLI binary (`schemaforge`) with SurrealDB, PostgreSQL, and SQL Server release flavors; routes configuration through `acton_service::Config<SchemaForgeConfig>` and supports trusted-proxy Windows authentication |
 
 ## Before You Build: acton-service Owns the Platform Layer
 


### PR DESCRIPTION
## Summary

- prevent Git Bash/MSYS from rewriting Sigstore identity regex arguments on Windows
- exercise console signature verification on the Windows PR runner
- bump the CLI release to 0.37.2 without moving the failed public v0.37.1 tag

## Validation

- `cargo check --package schema-forge-cli --bin schemaforge --no-default-features --features mssql`
- `actionlint .github/workflows/*.yml`